### PR TITLE
MVS alternative

### DIFF
--- a/vendor/github.com/42wim/mm-go-irckit/message_cache.go
+++ b/vendor/github.com/42wim/mm-go-irckit/message_cache.go
@@ -1,0 +1,101 @@
+package irckit
+
+import (
+	"sync"
+	"testing"
+)
+
+// represents the number of times a message has been sent
+// (in case a user submits the same message multiple times
+// before receiving it back)
+type messageCounts map[string]int
+
+// keeps track of message counts per channel
+type channelMessages map[string]messageCounts
+
+// our structure for keeping track of messages a user sent,
+// per-channel
+type messageCache struct {
+	cache channelMessages
+	m     sync.Mutex
+}
+
+// creates/instantiates a new message cache
+func newMessageCache() *messageCache {
+	return &messageCache{
+		cache: make(channelMessages),
+	}
+}
+
+// increments the message's count in our cache, for the given channel.
+// creates the messageCounts for that channel structure as needed.
+func (c *messageCache) addMessage(channel, message string) {
+	c.m.Lock()
+	defer c.m.Unlock()
+	if _, ok := c.cache[channel]; !ok {
+		// add this channel since it doesn't exist in the cache yet
+		c.cache[channel] = make(messageCounts)
+	}
+	c.cache[channel][message]++
+}
+
+// checks whether the given message is in our cache for the given channel.
+// if not, returns false.
+// if it is, decrements the message count for that channel and returns true.
+// deletes cache map and messageCounts entries as needed to save memory.
+func (c *messageCache) messageIn(channel, message string) bool {
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	if _, ok := c.cache[channel]; !ok {
+		// if the channel doesn't even exist, the user definitely didn't send the message
+		return false
+	}
+
+	_, ok := c.cache[channel][message]
+	if ok {
+		// user sent this message to this channel. decrement our count.
+		c.cache[channel][message]--
+
+		if c.cache[channel][message] <= 0 {
+			// if the count for this message in this channel reaches 0, we
+			// can evict that message rather than leaving it in our messageCounts map
+			delete(c.cache[channel], message)
+
+			if len(c.cache[channel]) == 0 {
+				// if there are no messages remaining in this channel, we can
+				// delete the entry for it
+				delete(c.cache, channel)
+			}
+		}
+		return true
+	}
+	return false
+}
+
+// TestMessageCache provides some basic tests for our sent message cache
+func TestMessageCache(t *testing.T) {
+	u := newMessageCache()
+	c, nc, s, ns := "test", "notest", "hello", "goodbye"
+	u.addMessage(c, s)
+	if u.messageIn(nc, s) {
+		t.Errorf("message [%s] should not be in but is!", s)
+	}
+	if u.messageIn(nc, ns) {
+		t.Errorf("message [%s] should not be in but is!", s)
+	}
+	if !u.messageIn(c, s) {
+		t.Errorf("message [%s] should be in but is not!", s)
+	}
+	if u.messageIn(c, s) {
+		t.Errorf("message [%s] should not be in but is!", s)
+	}
+	if u.messageIn(c, ns) {
+		t.Errorf("message [%s] should not be in but is!", s)
+	}
+	u.addMessage(c, s)
+	u.addMessage(c, s)
+	if !u.messageIn(c, s) || !u.messageIn(c, ns) {
+		t.Errorf("message [%s] should be in but is not!", s)
+	}
+}

--- a/vendor/github.com/42wim/mm-go-irckit/mmuser.go
+++ b/vendor/github.com/42wim/mm-go-irckit/mmuser.go
@@ -229,8 +229,8 @@ func (u *User) handleWsActionPost(rmsg *model.Message) {
 	data := model.PostFromJson(strings.NewReader(rmsg.Props["post"]))
 	logger.Debug("receiving userid", data.UserId)
 	if data.UserId == u.mc.User.Id {
-		// our own message - http://www.fileformat.info/info/unicode/char/180e/fontsupport.htm
-		if strings.Contains(data.Message, "᠎") {
+		// check if this is a message we sent; if so, ignore it
+		if u.ownMessages.messageIn(data.ChannelId, data.Message) {
 			logger.Debugf("message is sent from IRC, contains unicode, not relaying %#v", data.Message)
 			return
 		}

--- a/vendor/github.com/42wim/mm-go-irckit/server.go
+++ b/vendor/github.com/42wim/mm-go-irckit/server.go
@@ -789,7 +789,8 @@ func (s *server) handle(u *User) {
 					msg.Trailing = strings.Replace(msg.Trailing, "\x01ACTION ", "", -1)
 					msg.Trailing = "*" + msg.Trailing + "*"
 				}
-				msg.Trailing += "᠎"
+				// cache this user's message so that when it's echoed back to them they can ignore it
+				u.ownMessages.addMessage(u.mc.GetChannelId(p), msg.Trailing)
 				post := &model.Post{ChannelId: u.mc.GetChannelId(p), Message: msg.Trailing}
 				u.mc.Client.CreatePost(post)
 			} else if toUser, exists := s.HasUser(query); exists {

--- a/vendor/github.com/42wim/mm-go-irckit/user.go
+++ b/vendor/github.com/42wim/mm-go-irckit/user.go
@@ -11,9 +11,10 @@ import (
 // NewUser creates a *User, wrapping a connection with metadata we need for our server.
 func NewUser(c Conn) *User {
 	return &User{
-		Conn:     c,
-		Host:     "*",
-		channels: map[Channel]struct{}{},
+		Conn:        c,
+		Host:        "*",
+		channels:    map[Channel]struct{}{},
+		ownMessages: newMessageCache(),
 	}
 }
 
@@ -38,6 +39,8 @@ type User struct {
 	Host string
 
 	channels map[Channel]struct{}
+
+	ownMessages *messageCache
 
 	MmInfo
 }


### PR DESCRIPTION
This pull request presents an idea for alternative solution to the ["MVS problem"](https://github.com/42wim/matterircd/issues/24). Essentially, the user client tracks message counts per channel for messages they send; on the receiving side, they see if that message exists in their data structure, and if so, doesn't process it.

Some notes:

- It might be useful to add some sort of eviction timer to the cache, so that in the unlikely event an IRC user sends a message but doesn't receive it back, the structure doesn't end up with data that hangs around forever.
- A lot of work is done creating/deleting maps every time a message is sent; perhaps it'd be better to not do that, or put some sort of timer on that as well.
- I'm new to golang, so there's a very good chance I don't know what I'm doing, and I'm very sorry about that.

Good idea, bad idea? It seems to work for us. Hopefully there's at least something useful contained in here.

Thanks so much!
