### PR TITLE
handle fileids/pasted images

### DIFF
--- a/vendor/github.com/42wim/matterbridge/matterclient/matterclient.go
+++ b/vendor/github.com/42wim/matterbridge/matterclient/matterclient.go
@@ -413,6 +413,15 @@ func (m *MMClient) GetPublicLinks(filenames []string) []string {
 	return output
 }
 
+func (m *MMClient) GetDirectLinks(fileids []string) []string {
+	var output []string
+	for _, f := range fileids {
+		res := m.Client.ApiUrl + m.Client.GetFileRoute(f) + "/get"
+		output = append(output, res)
+	}
+	return output
+}
+
 func (m *MMClient) UpdateChannelHeader(channelId string, header string) {
 	data := make(map[string]string)
 	data["channel_id"] = channelId

--- a/vendor/github.com/42wim/mm-go-irckit/mmuser.go
+++ b/vendor/github.com/42wim/mm-go-irckit/mmuser.go
@@ -249,6 +249,18 @@ func (u *User) handleWsActionPost(rmsg *model.WebSocketEvent) {
 			}
 		}
 	}
+
+	if len(data.FileIds) > 0 {
+		logger.Debugf("fileids detected")
+		for _, fname := range u.mc.GetDirectLinks(data.FileIds) {
+			if props["channel_type"] == "D" {
+				u.MsgSpoofUser(spoofUsername, "download file - "+fname)
+			} else {
+				ch.SpoofMessage(spoofUsername, "download file - "+fname)
+			}
+		}
+	}
+
 	logger.Debugf("handleWsActionPost() user %s sent %s", u.mc.GetUser(data.UserId).Username, data.Message)
 	logger.Debugf("%#v", data)
 


### PR DESCRIPTION
Handle fileids / pasted images

DONT MERGE - I know this issue should be fixed properly in matterbridge first, but just wanted to get verification this approach would be valid fix.

Why:

 * there is no message sent when images or files sent

This change addreses the need by:

 * doing the same as was done for filenames, but fileid instead
   and using direct links rather than public ones.

Solves #82