### PR TITLE
Add http.ProxyFromEnvironment to use default env var like in net/http…

### DIFF
--- a/vendor/github.com/42wim/matterbridge/matterclient/matterclient.go
+++ b/vendor/github.com/42wim/matterbridge/matterclient/matterclient.go
@@ -106,7 +106,7 @@ func (m *MMClient) Login() error {
 	}
 	// login to mattermost
 	m.Client = model.NewClient(uriScheme + m.Credentials.Server)
-	m.Client.HttpClient.Transport = &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: m.SkipTLSVerify}}
+	m.Client.HttpClient.Transport = &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: m.SkipTLSVerify}, Proxy: http.ProxyFromEnvironment}
 	m.Client.HttpClient.Timeout = time.Second * 10
 	// bogus call to get the serverversion
 	m.Client.GetClientProperties()


### PR DESCRIPTION
Add standard http client proxy possibility to matterircd like DefaultTransport in net/http/transport.go.

=> To report on matterbridge/matterclient