### PR TITLE
Allow users to skip TLS Certificate chain verification.

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,16 +4,17 @@ import (
 	"crypto/tls"
 	"flag"
 	"fmt"
-	"github.com/42wim/mm-go-irckit"
-	"github.com/Sirupsen/logrus"
 	"net"
 	"os"
 	"strings"
+
+	"github.com/42wim/mm-go-irckit"
+	"github.com/Sirupsen/logrus"
 )
 
 var (
 	flagRestrict, flagDefaultTeam, flagDefaultServer, flagTLSBind, flagTLSDir *string
-	flagInsecure                                                              *bool
+	flagInsecure, flagSkipTLSVerify                                           *bool
 	version                                                                   = "0.14.0"
 	githash                                                                   string
 	logger                                                                    *logrus.Entry
@@ -31,6 +32,7 @@ func main() {
 	flagVersion := flag.Bool("version", false, "show version")
 	flagTLSBind = flag.String("tlsbind", "", "interface:port to bind to. (e.g 127.0.0.1:6697)")
 	flagTLSDir = flag.String("tlsdir", ".", "directory to look for key.pem and cert.pem.")
+	flagSkipTLSVerify = flag.Bool("mmskiptlsverify", false, "Skip verification of the servers certificate chain and hostname (default: false)")
 	flag.Parse()
 
 	ourlog := logrus.New()
@@ -107,7 +109,7 @@ func start(socket net.Listener) {
 		go func() {
 			cfg := &irckit.MmCfg{AllowedServers: strings.Fields(*flagRestrict),
 				DefaultTeam: *flagDefaultTeam, DefaultServer: *flagDefaultServer,
-				Insecure: *flagInsecure}
+				Insecure: *flagInsecure, SkipTLSVerify: *flagSkipTLSVerify}
 			newsrv := irckit.ServerConfig{Name: "matterircd", Version: version}.Server()
 			logger.Infof("New connection: %s", conn.RemoteAddr())
 			err = newsrv.Connect(irckit.NewUserMM(conn, newsrv, cfg))


### PR DESCRIPTION
We run an internal CA, and our mattermost instance uses a certificate issued by that CA.  To connect matterircd to mattermost, we needed to allow it to skip TLS Certificate verification.