### PR TITLE
enable mattermost login via irc PASS command during handshake instead of PRIVMSG

### DIFF
--- a/vendor/github.com/42wim/mm-go-irckit/user.go
+++ b/vendor/github.com/42wim/mm-go-irckit/user.go
@@ -36,6 +36,7 @@ type User struct {
 	Nick        string // From NICK command
 	User        string // From USER command
 	Real        string // From USER command
+	Pass        []string // From PASS command
 	Host        string
 	Roles       string
 	DisplayName string


### PR DESCRIPTION
this allows to just pass the mattermost credentials as the server password in the irc client