### PR TITLE
Add handling of reactions, stars and pins

### DIFF
--- a/mm-go-irckit/slackuser.go
+++ b/mm-go-irckit/slackuser.go
@@ -357,8 +357,7 @@ func (u *User) handleSlackActionMisc(userid string, channel string, message stri
 		}
 	}
 
-	msgs := []string{}
-	msgs = append(msgs, message)
+	msgs := strings.Split(message, "\n")
 
 	// direct message
 	ch = u.Srv.Channel(channel)

--- a/mm-go-irckit/slackuser.go
+++ b/mm-go-irckit/slackuser.go
@@ -339,7 +339,7 @@ func (u *User) handleSlackActionMisc(userid string, channel string, message stri
 
 	user, err := u.rtm.GetUserInfo(userid)
 	if err != nil {
-    return
+		return
 	}
 
 	// create new "ghost" user
@@ -358,8 +358,7 @@ func (u *User) handleSlackActionMisc(userid string, channel string, message stri
 	}
 
 	msgs := []string{}
-  msgs = append(msgs, message)
-
+	msgs = append(msgs, message)
 
 	// direct message
 	ch = u.Srv.Channel(channel)
@@ -378,7 +377,6 @@ func (u *User) handleSlackActionMisc(userid string, channel string, message stri
 			ch.Join(u)
 		}
 	}
-
 
 	spoofUsername = strings.Replace(spoofUsername, " ", "_", -1)
 	for _, m := range msgs {

--- a/mm-go-irckit/slackuser.go
+++ b/mm-go-irckit/slackuser.go
@@ -3,6 +3,7 @@ package irckit
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"html"
 	"io/ioutil"
 	"net/http"


### PR DESCRIPTION
This handles some common Slack events. They show up as new messages:
```
10:21:04 < someuser> Such wow
10:28:05 < otheruser> [M 10:21:04] Added reaction :ok_hand:
```