### PR TITLE
Added a default value for the '-conf' flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ func main() {
 
 	// config related. instantiate a new config.Config to store flags
 	cfg = config.Config{}
-	flagConfig := flag.String("conf", "", "config file")
+	flagConfig := flag.String("conf", "/usr/local/etc/matterircd/matterircd.toml", "config file")
 
 	// bools for showing version/enabling debug
 	flagVersion := flag.Bool("version", false, "show version")
@@ -52,8 +52,8 @@ func main() {
 
 	// migrate config settings to mattermost settings
 	cfg = *config.Migrate(cfg)
-	// if -config was set, load the config file (overrides args)
-	if *flagConfig != "" {
+	// Attempt to load values from the config file
+	if _, err = os.Stat(*flagConfig); err == nil {
 		cfg = *config.LoadConfig(*flagConfig, cfg)
 	}
 

--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ func main() {
 	// migrate config settings to mattermost settings
 	cfg = *config.Migrate(cfg)
 	// Attempt to load values from the config file
-	if _, err = os.Stat(*flagConfig); err == nil {
+	if _, err := os.Stat(*flagConfig); err == nil {
 		cfg = *config.LoadConfig(*flagConfig, cfg)
 	}
 

--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ func main() {
 
 	// config related. instantiate a new config.Config to store flags
 	cfg = config.Config{}
-	flagConfig := flag.String("conf", "/usr/local/etc/matterircd/matterircd.toml", "config file")
+	flagConfig := flag.String("conf", "matterircd.toml", "config file")
 
 	// bools for showing version/enabling debug
 	flagVersion := flag.Bool("version", false, "show version")

--- a/mm-go-irckit/user.go
+++ b/mm-go-irckit/user.go
@@ -156,7 +156,7 @@ func (user *User) Decode() {
 	stop := make(chan struct{})
 	bufferTimeout := user.Cfg.PasteBufferTimeout
 	// we need at least 100
-	if bufferTimeout == 0 {
+	if bufferTimeout < 100 {
 		bufferTimeout = 100
 	}
 	logger.Debugf("using paste buffer timeout: %#v\n", bufferTimeout)


### PR DESCRIPTION
By default matterircd doesn't attempt to read any config file, now it
will attempt to read from /usr/local/etc/matterircd/matterircd.toml if
it exists.