### PR TITLE
Add option to use Nickname instead of Username

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -42,6 +42,7 @@ type Settings struct {
 	UseDisplayName  bool
 	PrefixMainTeam  bool
 	DisableAutoView bool
+	PreferNickname  bool
 }
 
 func Migrate(defaultcfg Config) *Config {

--- a/matterircd.toml.example
+++ b/matterircd.toml.example
@@ -70,6 +70,11 @@ PrefixMainTeam = false
 #(anti-idle support is turned off) (default false)
 DisableAutoView = false
 
+# If users set a Nickname, matterircd could either choose that or the Username
+# to display in the IRC client. The option PreferNickname controls that, the
+# default being to show the Username. (default false)
+PreferNickname = false
+
 #############################
 ##### SLACK EXAMPLE #########
 #############################

--- a/mm-go-irckit/mmservice.go
+++ b/mm-go-irckit/mmservice.go
@@ -191,8 +191,14 @@ func search(u *User, toUser *User, args []string, service string) {
 		}
 		timestamp := time.Unix(postlist.Posts[postlist.Order[i]].CreateAt/1000, 0).Format("January 02, 2006 15:04")
 		channelname := u.mc.GetChannelName(postlist.Posts[postlist.Order[i]].ChannelId)
-		u.MsgUser(toUser, "#"+channelname+" <"+u.mc.GetUser(postlist.Posts[postlist.Order[i]].UserId).Username+"> "+timestamp)
-		u.MsgUser(toUser, strings.Repeat("=", len("#"+channelname+" <"+u.mc.GetUser(postlist.Posts[postlist.Order[i]].UserId).Username+"> "+timestamp)))
+
+		nick := u.mc.GetUser(postlist.Posts[postlist.Order[i]].UserId).Username
+		if (u.Cfg.PreferNickname &&
+		    u.isValidNick(u.mc.GetUser(postlist.Posts[postlist.Order[i]].UserId).Nickname)) {
+			nick = u.mc.GetUser(postlist.Posts[postlist.Order[i]].UserId).Nickname
+		}
+		u.MsgUser(toUser, "#"+channelname+" <"+nick+"> "+timestamp)
+		u.MsgUser(toUser, strings.Repeat("=", len("#"+channelname+" <"+nick+"> "+timestamp)))
 		for _, post := range strings.Split(postlist.Posts[postlist.Order[i]].Message, "\n") {
 			if post != "" {
 				u.MsgUser(toUser, post)
@@ -252,6 +258,10 @@ func scrollback(u *User, toUser *User, args []string, service string) {
 	}
 	for i := len(postlist.Order) - 1; i >= 0; i-- {
 		nick := u.mc.GetUser(postlist.Posts[postlist.Order[i]].UserId).Username
+		if (u.Cfg.PreferNickname &&
+		    u.isValidNick(u.mc.GetUser(postlist.Posts[postlist.Order[i]].UserId).Nickname)) {
+			nick = u.mc.GetUser(postlist.Posts[postlist.Order[i]].UserId).Nickname
+		}
 		for _, post := range strings.Split(postlist.Posts[postlist.Order[i]].Message, "\n") {
 			if post != "" {
 				u.MsgUser(toUser, "<"+nick+"> "+post)

--- a/mm-go-irckit/mmuser.go
+++ b/mm-go-irckit/mmuser.go
@@ -43,6 +43,7 @@ type MmCfg struct {
 	PrefixMainTeam     bool
 	PasteBufferTimeout int
 	DisableAutoView    bool
+	PreferNickname     bool
 }
 
 func NewUserMM(c net.Conn, srv Server, cfg *MmCfg) *User {
@@ -63,6 +64,7 @@ func NewUserMM(c net.Conn, srv Server, cfg *MmCfg) *User {
 	u.MmInfo.Cfg.SkipTLSVerify = cfg.MattermostSettings.SkipTLSVerify
 	u.MmInfo.Cfg.PrefixMainTeam = cfg.MattermostSettings.PrefixMainTeam
 	u.MmInfo.Cfg.DisableAutoView = cfg.MattermostSettings.DisableAutoView
+	u.MmInfo.Cfg.PreferNickname = cfg.MattermostSettings.PreferNickname
 
 	u.idleStop = make(chan struct{})
 	// used for login
@@ -114,14 +116,57 @@ func (u *User) logoutFromMattermost() error {
 	return nil
 }
 
+func (u *User) isValidNick(s string) bool {
+	/* IRC RFC ([0] - see below) mentions a limit of 9 chars for
+	 * IRC nicks, but modern clients allow more than that. Let's
+	 * use a "sane" big value, the triple of the spec.
+	 */
+	if (len(s) < 1 || len(s) > 27) {
+		return false
+	}
+
+	/* According to IRC RFC [0], the allowed chars to have as nick
+	 * are: ( letter / special-'-' ).*( letter / digit / special ),
+	 * where:
+	 * letter = [a-z / A-Z]; digit = [0-9];
+	 * special = [';', '[', '\', ']', '^', '_', '`', '{', '|', '}', '-']
+	 *
+	 * ASCII codes (decimal) for the allowed chars:
+	 * letter = [65-90,97-122]; digit = [48-57]
+	 * special = [59, 91-96, 123-125, 45]
+	 * [0] RFC 2812 (tools.ietf.org/html/rfc2812)
+	 */
+
+	if (s[0] != 59 && (s[0] < 65 || s[0] > 125)) {
+		return false
+	}
+
+	for i := 1; i < len(s); i++ {
+		if (s[i] != 45 && s[i] != 59 && (s[i] < 65 || s[i] > 125)) {
+			if (s[i] < 48 || s[i] > 57) {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
 func (u *User) createMMUser(mmuser *model.User) *User {
 	if mmuser == nil {
 		return nil
 	}
-	if ghost, ok := u.Srv.HasUser(mmuser.Username); ok {
+
+	nick := mmuser.Username
+	if (u.Cfg.PreferNickname && u.isValidNick(mmuser.Nickname)) {
+		nick = mmuser.Nickname
+	}
+
+	if ghost, ok := u.Srv.HasUser(nick); ok {
 		return ghost
 	}
-	ghost := &User{Nick: mmuser.Username, User: mmuser.Id, Real: mmuser.FirstName + " " + mmuser.LastName, Host: u.mc.Client.Url, Roles: mmuser.Roles, channels: map[Channel]struct{}{}}
+
+	ghost := &User{Nick: nick, User: mmuser.Id, Real: mmuser.FirstName + " " + mmuser.LastName, Host: u.mc.Client.Url, Roles: mmuser.Roles, channels: map[Channel]struct{}{}}
 	ghost.MmGhostUser = true
 	u.Srv.Add(ghost)
 	return ghost
@@ -240,7 +285,11 @@ func (u *User) addUserToChannelWorker(channels <-chan *model.Channel, throttle <
 						spoof("matterircd", fmt.Sprintf("Replaying since %s", date))
 						prevDate = date
 					}
-					spoof(user.Username, fmt.Sprintf("[%s] %s", ts.Format("15:04"), post))
+					nick := user.Username
+					if (u.Cfg.PreferNickname && u.isValidNick(user.Nickname)) {
+						nick = user.Nickname
+					}
+					spoof(nick, fmt.Sprintf("[%s] %s", ts.Format("15:04"), post))
 				}
 			}
 		}


### PR DESCRIPTION
Currently matterircd uses Username as the nick handler for every
user, regardless if such user have a Nickname set. There is an inherent
restriction on using the Nickname - they may contain non-ascii chars,
breaking compatibility with IRC clients.

This patch adds the config option PreferNickname - if set, we check
Nickname and if it's not empty and doesn't contain any non-ascii
character, matterircd uses the Nickname instead of Username.
It's a Mattermost-only option for the time being.

Signed-off-by: Guilherme G. Piccoli <gpiccoli@canonical.com>

V2 just uploaded (2020-06-23): instead of checking just for ASCII chars, stick with
IRC RFC and limit the nicknames according to this specification (and to max of 27 chars).