### PR TITLE
Add option to disable showing replies/parent posts

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -43,6 +43,7 @@ type Settings struct {
 	PrefixMainTeam  bool
 	DisableAutoView bool
 	PreferNickname  bool
+	HideReplies     bool
 }
 
 func Migrate(defaultcfg Config) *Config {

--- a/matterircd.toml.example
+++ b/matterircd.toml.example
@@ -75,6 +75,9 @@ DisableAutoView = false
 # default being to show the Username. (default false)
 PreferNickname = false
 
+# Disable showing parent post / replies
+HideReplies = false
+
 #############################
 ##### SLACK EXAMPLE #########
 #############################

--- a/mm-go-irckit/mmuser.go
+++ b/mm-go-irckit/mmuser.go
@@ -45,6 +45,7 @@ type MmCfg struct {
 	PasteBufferTimeout int
 	DisableAutoView    bool
 	PreferNickname     bool
+	HideReplies        bool
 }
 
 func NewUserMM(c net.Conn, srv Server, cfg *MmCfg) *User {
@@ -66,6 +67,7 @@ func NewUserMM(c net.Conn, srv Server, cfg *MmCfg) *User {
 	u.MmInfo.Cfg.PrefixMainTeam = cfg.MattermostSettings.PrefixMainTeam
 	u.MmInfo.Cfg.DisableAutoView = cfg.MattermostSettings.DisableAutoView
 	u.MmInfo.Cfg.PreferNickname = cfg.MattermostSettings.PreferNickname
+	u.MmInfo.Cfg.HideReplies = cfg.MattermostSettings.HideReplies
 
 	u.idleStop = make(chan struct{})
 	// used for login
@@ -356,7 +358,11 @@ func (u *User) handleWsActionPost(rmsg *model.WebSocketEvent) {
 			logger.Debugf("Unable to get parent post for %#v", data)
 		} else {
 			parentGhost := u.createMMUser(u.mc.GetUser(parentPost.UserId))
-			data.Message = fmt.Sprintf("%s (re @%s: %s)", data.Message, parentGhost.Nick, parentPost.Message)
+			if u.Cfg.HideReplies {
+				data.Message = fmt.Sprintf("%s (re @%s)", data.Message, parentGhost.Nick)
+			} else {
+				data.Message = fmt.Sprintf("%s (re @%s: %s)", data.Message, parentGhost.Nick, parentPost.Message)
+			}
 		}
 	}
 	// create new "ghost" user


### PR DESCRIPTION
Example with config option enabled:

`|12:26 <hloeung> Testing (re @hloeung)`

So it will only show (re @nick_of_user) without the post message that the reply is made to.