### PR TITLE
Fix crash on topic change due to invalid user's nickname

### DIFF
--- a/mm-go-irckit/mmuser.go
+++ b/mm-go-irckit/mmuser.go
@@ -460,7 +460,16 @@ func (u *User) handleWsActionPost(rmsg *model.WebSocketEvent) {
 		ch = u.Srv.Channel(data.ChannelId)
 		if topic, ok := extraProps["new_header"].(string); ok {
 			if topicuser, ok := extraProps["username"].(string); ok {
-				tu, _ := u.Srv.HasUser(topicuser)
+				tu, valid := u.Srv.HasUser(topicuser)
+				if !valid {
+					logger.Debugf("Detected invalid user/nick: %s/%s",
+						u.mc.GetUserName(data.UserId), u.mc.GetNickName(data.UserId))
+					tu, _ = u.Srv.HasUser(u.mc.GetUserName(data.UserId))
+					if tu == nil {
+						logger.Warnf("Ugh, detected NIL, returning")
+						return
+					}
+				}
 				ch.Topic(tu, topic)
 			}
 		}


### PR DESCRIPTION
After running the code with commit 50e16b8624 (that introduced the ability
of using nicks), I've noticed in rare occasions we could face a crash on
topic/system_header change due to invalid nickname. I believe this is related
to other users clearing their nicks after the start of matterircd.

The way I've fixed that was to add some additional checks to system_header
change event, and then was able to run several weeks without crashes
(although the checks were triggered sometimes, preventing the NIL crash).
Notice the Warn was never reached though, but I kept that for safety!

Fixes: 50e16b8624 ["Add option to use Nickname instead of Username (#273)"]
Signed-off-by: Guilherme G. Piccoli <gpiccoli@canonical.com>