### PR TITLE
Fix crash on quit without login

### DIFF
--- a/mm-go-irckit/server_commands.go
+++ b/mm-go-irckit/server_commands.go
@@ -395,7 +395,10 @@ func CmdQuit(s Server, u *User, msg *irc.Message) error {
 	s.EncodeMessage(u, irc.QUIT, []string{}, partMsg)
 	s.EncodeMessage(u, irc.ERROR, []string{}, "You will be missed.")
 
-	u.br.Logout()
+	if u.br != nil {
+		// u.br may be nil when the user is not yet logged in by the time we quit.
+		u.br.Logout()
+	}
 	u.Srv.Logout(u)
 
 	u.Conn.Close()


### PR DESCRIPTION
This is especially useful with multiple users. So if a user tries to
log in, but quits after a failed attempt, other users are not affected.

Fixes #298