### PR TITLE
Fix noise from printing private channel mode (#301)

### DIFF
--- a/mm-go-irckit/server_commands.go
+++ b/mm-go-irckit/server_commands.go
@@ -196,7 +196,6 @@ func CmdMode(s Server, u *User, msg *irc.Message) error {
 
 	if s.Channel(channel).IsPrivate() {
 		mode = "p"
-		fmt.Println(mode)
 	}
 
 	r := []*irc.Message{}


### PR DESCRIPTION
Get's rid of the extra `p`'s output.