### PR TITLE
Support for adding message/thread context at the end

### DIFF
--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -690,7 +690,7 @@ func (m *Mattermost) handleWsActionPost(rmsg *model.WebSocketEvent) {
 	}
 
 	// nolint:nestif
-	if !m.v.GetBool("mattermost.prefixContext") && data.ParentId != "" {
+	if !(m.v.GetBool("mattermost.prefixContext") || m.v.GetBool("mattermost.suffixContext")) && data.ParentId != "" {
 		parentPost, resp := m.mc.Client.GetPost(data.ParentId, "")
 		if resp.Error != nil {
 			logger.Errorf("Unable to get parent post for %#v", data)

--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -690,13 +690,14 @@ func (m *Mattermost) handleWsActionPost(rmsg *model.WebSocketEvent) {
 	}
 
 	// nolint:nestif
-	if !(m.v.GetBool("mattermost.prefixContext") || m.v.GetBool("mattermost.suffixContext")) && data.ParentId != "" {
+	if data.ParentId != "" {
 		parentPost, resp := m.mc.Client.GetPost(data.ParentId, "")
 		if resp.Error != nil {
 			logger.Errorf("Unable to get parent post for %#v", data)
 		} else {
 			parentGhost := m.GetUser(parentPost.UserId)
-			if m.v.GetBool("mattermost.HideReplies") {
+			// Include parent userid / IRC nicks so hilights still work when people reply to our messages.
+			if m.v.GetBool("mattermost.HideReplies") || m.v.GetBool("mattermost.prefixContext") || m.v.GetBool("mattermost.suffixContext") {
 				data.Message = fmt.Sprintf("%s (re @%s)", data.Message, parentGhost.Nick)
 			} else {
 				data.Message = fmt.Sprintf("%s (re @%s: %s)", data.Message, parentGhost.Nick, parentPost.Message)

--- a/matterircd.toml.example
+++ b/matterircd.toml.example
@@ -114,6 +114,8 @@ JoinDM = false
 #This number will be referenced when a message is edited/deleted/threaded/reaction
 #For more information see prefixcontext.md
 PrefixContext = false
+# Same as PrefixContext but with the message context at the end.
+SuffixContenxt = false
 
 #This will show (mention yournick) after a message if it contains one of the words configured
 #in your mattermost "word that trigger mentions" notifications.

--- a/mm-go-irckit/server_commands.go
+++ b/mm-go-irckit/server_commands.go
@@ -378,7 +378,7 @@ func CmdPrivMsg(s Server, u *User, msg *irc.Message) error {
 			u.MsgSpoofUser(u, u.br.Protocol(), "msg: "+msg.Trailing+" could not be send: "+err.Error())
 		}
 
-		if u.v.GetBool(u.br.Protocol() + ".prefixcontext") || u.v.GetBool(u.br.Protocol() + ".suffixcontext") {
+		if u.v.GetBool(u.br.Protocol()+".prefixcontext") || u.v.GetBool(u.br.Protocol()+".suffixcontext") {
 			u.prefixContext(ch.ID(), msgID, "", "")
 		}
 
@@ -406,7 +406,7 @@ func CmdPrivMsg(s Server, u *User, msg *irc.Message) error {
 				return err
 			}
 
-			if u.v.GetBool(u.br.Protocol() + ".prefixcontext") || u.v.GetBool(u.br.Protocol() + ".suffixcontext") {
+			if u.v.GetBool(u.br.Protocol()+".prefixcontext") || u.v.GetBool(u.br.Protocol()+".suffixcontext") {
 				u.prefixContext(toUser.User, msgID, "", "")
 			}
 

--- a/mm-go-irckit/server_commands.go
+++ b/mm-go-irckit/server_commands.go
@@ -378,7 +378,7 @@ func CmdPrivMsg(s Server, u *User, msg *irc.Message) error {
 			u.MsgSpoofUser(u, u.br.Protocol(), "msg: "+msg.Trailing+" could not be send: "+err.Error())
 		}
 
-		if u.v.GetBool(u.br.Protocol() + ".prefixcontext") {
+		if u.v.GetBool(u.br.Protocol() + ".prefixcontext") || u.v.GetBool(u.br.Protocol() + ".suffixcontext") {
 			u.prefixContext(ch.ID(), msgID, "", "")
 		}
 
@@ -406,7 +406,7 @@ func CmdPrivMsg(s Server, u *User, msg *irc.Message) error {
 				return err
 			}
 
-			if u.v.GetBool(u.br.Protocol() + ".prefixcontext") {
+			if u.v.GetBool(u.br.Protocol() + ".prefixcontext") || u.v.GetBool(u.br.Protocol() + ".suffixcontext") {
 				u.prefixContext(toUser.User, msgID, "", "")
 			}
 

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -111,22 +111,21 @@ func (u *User) handleDirectMessageEvent(event *bridge.DirectMessageEvent) {
 		}
 	}
 
-	// nolint:nestif
-	if u.v.GetBool(u.br.Protocol()+".prefixcontext") || u.v.GetBool(u.br.Protocol()+".suffixcontext") {
+	if u.v.GetBool(u.br.Protocol() + ".prefixcontext") {
 		prefix := u.prefixContext(event.Sender.User, event.MessageID, event.ParentID, event.Event)
 
-		if u.v.GetBool(u.br.Protocol() + ".prefixcontext") {
-			if strings.HasPrefix(event.Text, "\x01") {
-				event.Text = strings.Replace(event.Text, "\x01ACTION ", "\x01ACTION "+prefix+" ", 1)
-			} else {
-				event.Text = prefix + " " + event.Text
-			}
+		if strings.HasPrefix(event.Text, "\x01") {
+			event.Text = strings.Replace(event.Text, "\x01ACTION ", "\x01ACTION "+prefix+" ", 1)
 		} else {
-			if strings.HasSuffix(event.Text, "\x01") {
-				event.Text = strings.Replace(event.Text, " \x01", " "+prefix+" \x01", 1)
-			} else {
-				event.Text = event.Text + " " + prefix
-			}
+			event.Text = prefix + " " + event.Text
+		}
+	} else if u.v.GetBool(u.br.Protocol() + ".suffixcontext") {
+		prefix := u.prefixContext(event.Sender.User, event.MessageID, event.ParentID, event.Event)
+
+		if strings.HasSuffix(event.Text, "\x01") {
+			event.Text = strings.Replace(event.Text, " \x01", " "+prefix+" \x01", 1)
+		} else {
+			event.Text = event.Text + " " + prefix
 		}
 	}
 
@@ -243,22 +242,21 @@ func (u *User) handleChannelMessageEvent(event *bridge.ChannelMessageEvent) {
 		}
 	}
 
-	// nolint:nestif
-	if u.v.GetBool(u.br.Protocol()+".prefixcontext") || u.v.GetBool(u.br.Protocol()+".suffixcontext") {
+	if u.v.GetBool(u.br.Protocol() + ".prefixcontext") {
 		prefix := u.prefixContext(event.ChannelID, event.MessageID, event.ParentID, event.Event)
 
-		if u.v.GetBool(u.br.Protocol() + ".prefixcontext") {
-			if strings.HasPrefix(event.Text, "\x01") {
-				event.Text = strings.Replace(event.Text, "\x01ACTION ", "\x01ACTION "+prefix+" ", 1)
-			} else {
-				event.Text = prefix + " " + event.Text
-			}
+		if strings.HasPrefix(event.Text, "\x01") {
+			event.Text = strings.Replace(event.Text, "\x01ACTION ", "\x01ACTION "+prefix+" ", 1)
 		} else {
-			if strings.HasSuffix(event.Text, "\x01") {
-				event.Text = strings.Replace(event.Text, " \x01", " "+prefix+" \x01", 1)
-			} else {
-				event.Text = event.Text + " " + prefix
-			}
+			event.Text = prefix + " " + event.Text
+		}
+	} else if u.v.GetBool(u.br.Protocol() + ".suffixcontext") {
+		prefix := u.prefixContext(event.ChannelID, event.MessageID, event.ParentID, event.Event)
+
+		if strings.HasSuffix(event.Text, "\x01") {
+			event.Text = strings.Replace(event.Text, " \x01", " "+prefix+" \x01", 1)
+		} else {
+			event.Text = event.Text + " " + prefix
 		}
 	}
 

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -111,13 +111,17 @@ func (u *User) handleDirectMessageEvent(event *bridge.DirectMessageEvent) {
 		}
 	}
 
-	if u.v.GetBool(u.br.Protocol() + ".prefixcontext") {
+	if u.v.GetBool(u.br.Protocol() + ".prefixcontext") || u.v.GetBool(u.br.Protocol() + ".suffixcontext") {
 		prefix := u.prefixContext(event.Sender.User, event.MessageID, event.ParentID, event.Event)
 
-		if strings.HasPrefix(event.Text, "\x01") {
-			event.Text = strings.Replace(event.Text, "\x01ACTION ", "\x01ACTION "+prefix, 1)
+		if u.v.GetBool(u.br.Protocol() + ".prefixcontext") {
+			if strings.HasPrefix(event.Text, "\x01") {
+				event.Text = strings.Replace(event.Text, "\x01ACTION ", "\x01ACTION "+prefix+" ", 1)
+			} else {
+				event.Text = prefix + " " + event.Text
+			}
 		} else {
-			event.Text = prefix + event.Text
+			event.Text = event.Text + " " + prefix
 		}
 	}
 
@@ -234,13 +238,17 @@ func (u *User) handleChannelMessageEvent(event *bridge.ChannelMessageEvent) {
 		}
 	}
 
-	if u.v.GetBool(u.br.Protocol() + ".prefixcontext") {
+	if u.v.GetBool(u.br.Protocol() + ".prefixcontext") || u.v.GetBool(u.br.Protocol() + ".suffixcontext") {
 		prefix := u.prefixContext(event.ChannelID, event.MessageID, event.ParentID, event.Event)
 
-		if strings.HasPrefix(event.Text, "\x01") {
-			event.Text = strings.Replace(event.Text, "\x01ACTION ", "\x01ACTION "+prefix, 1)
+		if u.v.GetBool(u.br.Protocol() + ".prefixcontext") {
+			if strings.HasPrefix(event.Text, "\x01") {
+				event.Text = strings.Replace(event.Text, "\x01ACTION ", "\x01ACTION "+prefix+" ", 1)
+			} else {
+				event.Text = prefix + " " + event.Text
+			}
 		} else {
-			event.Text = prefix + event.Text
+			event.Text = event.Text + " " + prefix
 		}
 	}
 
@@ -746,7 +754,7 @@ func (u *User) prefixContextModified(channelID, messageID string) string {
 		currentcount = u.increaseMsgCounter(channelID)
 	}
 
-	return fmt.Sprintf("[%03x] ", currentcount)
+	return fmt.Sprintf("[%03x]", currentcount)
 }
 
 func (u *User) prefixContext(channelID, messageID, parentID, event string) string {
@@ -784,10 +792,10 @@ func (u *User) prefixContext(channelID, messageID, parentID, event string) strin
 	u.msgMap[channelID][messageID] = u.msgCounter[channelID]
 
 	if parentID != "" {
-		return fmt.Sprintf("[%03x->%03x] ", currentcount, parentcount)
+		return fmt.Sprintf("[%03x->%03x]", currentcount, parentcount)
 	}
 
-	return fmt.Sprintf("[%03x] ", currentcount)
+	return fmt.Sprintf("[%03x]", currentcount)
 }
 
 func (u *User) updateLastViewed(channelID string) {

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -111,7 +111,7 @@ func (u *User) handleDirectMessageEvent(event *bridge.DirectMessageEvent) {
 		}
 	}
 
-	if u.v.GetBool(u.br.Protocol() + ".prefixcontext") || u.v.GetBool(u.br.Protocol() + ".suffixcontext") {
+	if u.v.GetBool(u.br.Protocol()+".prefixcontext") || u.v.GetBool(u.br.Protocol()+".suffixcontext") {
 		prefix := u.prefixContext(event.Sender.User, event.MessageID, event.ParentID, event.Event)
 
 		if u.v.GetBool(u.br.Protocol() + ".prefixcontext") {
@@ -242,7 +242,7 @@ func (u *User) handleChannelMessageEvent(event *bridge.ChannelMessageEvent) {
 		}
 	}
 
-	if u.v.GetBool(u.br.Protocol() + ".prefixcontext") || u.v.GetBool(u.br.Protocol() + ".suffixcontext") {
+	if u.v.GetBool(u.br.Protocol()+".prefixcontext") || u.v.GetBool(u.br.Protocol()+".suffixcontext") {
 		prefix := u.prefixContext(event.ChannelID, event.MessageID, event.ParentID, event.Event)
 
 		if u.v.GetBool(u.br.Protocol() + ".prefixcontext") {

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -111,6 +111,7 @@ func (u *User) handleDirectMessageEvent(event *bridge.DirectMessageEvent) {
 		}
 	}
 
+	// nolint:nestif
 	if u.v.GetBool(u.br.Protocol()+".prefixcontext") || u.v.GetBool(u.br.Protocol()+".suffixcontext") {
 		prefix := u.prefixContext(event.Sender.User, event.MessageID, event.ParentID, event.Event)
 
@@ -242,6 +243,7 @@ func (u *User) handleChannelMessageEvent(event *bridge.ChannelMessageEvent) {
 		}
 	}
 
+	// nolint:nestif
 	if u.v.GetBool(u.br.Protocol()+".prefixcontext") || u.v.GetBool(u.br.Protocol()+".suffixcontext") {
 		prefix := u.prefixContext(event.ChannelID, event.MessageID, event.ParentID, event.Event)
 

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -121,7 +121,11 @@ func (u *User) handleDirectMessageEvent(event *bridge.DirectMessageEvent) {
 				event.Text = prefix + " " + event.Text
 			}
 		} else {
-			event.Text = event.Text + " " + prefix
+			if strings.HasSuffix(event.Text, "\x01") {
+				event.Text = strings.Replace(event.Text, " \x01", " "+prefix+" \x01", 1)
+			} else {
+				event.Text = event.Text + " " + prefix
+			}
 		}
 	}
 
@@ -248,7 +252,11 @@ func (u *User) handleChannelMessageEvent(event *bridge.ChannelMessageEvent) {
 				event.Text = prefix + " " + event.Text
 			}
 		} else {
-			event.Text = event.Text + " " + prefix
+			if strings.HasSuffix(event.Text, "\x01") {
+				event.Text = strings.Replace(event.Text, " \x01", " "+prefix+" \x01", 1)
+			} else {
+				event.Text = event.Text + " " + prefix
+			}
 		}
 	}
 


### PR DESCRIPTION
Add support similar to prefixContext but have the message/thread context at the end of the message.

We also want to include the parent posts' user nick so that configured IRC clients would still highlight on replies to a user's reply.