### PR TITLE
Add basic threading support (without prefix context)

### DIFF
--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -698,9 +698,9 @@ func (m *Mattermost) handleWsActionPost(rmsg *model.WebSocketEvent) {
 			parentGhost := m.GetUser(parentPost.UserId)
 			// Include parent userid / IRC nicks so hilights still work when people reply to our messages.
 			if m.v.GetBool("mattermost.HideReplies") || m.v.GetBool("mattermost.prefixContext") || m.v.GetBool("mattermost.suffixContext") {
-				data.Message = fmt.Sprintf("%s (re @%s)", data.Message, parentGhost.Nick)
+				data.Message = fmt.Sprintf("%s (re @%s (@@%s))", data.Message, parentGhost.Nick, data.ParentId)
 			} else {
-				data.Message = fmt.Sprintf("%s (re @%s: %s)", data.Message, parentGhost.Nick, parentPost.Message)
+				data.Message = fmt.Sprintf("%s (re @%s: %s (@@%s))", data.Message, parentGhost.Nick, parentPost.Message, data.ParentId)
 			}
 		}
 	}

--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -706,7 +706,7 @@ func (m *Mattermost) handleWsActionPost(rmsg *model.WebSocketEvent) {
 			parentGhost := m.GetUser(parentPost.UserId)
 			parentIDString := ""
 			if m.v.GetBool("mattermost.ThreadSupport") {
-				parentIDString = fmt.Sprintf(" (@@%s)", data.ParentId)
+				parentIDString = fmt.Sprintf(" @@%s", data.ParentId)
 			}
 			// Include parent userid / IRC nicks so hilights still work when people reply to our messages.
 			if m.v.GetBool("mattermost.HideReplies") || m.v.GetBool("mattermost.prefixContext") || m.v.GetBool("mattermost.suffixContext") {
@@ -715,6 +715,8 @@ func (m *Mattermost) handleWsActionPost(rmsg *model.WebSocketEvent) {
 				data.Message = fmt.Sprintf("%s (re @%s: %s%s)", data.Message, parentGhost.Nick, parentPost.Message, parentIDString)
 			}
 		}
+	} else if m.v.GetBool("mattermost.ThreadSupport") {
+		data.Message = fmt.Sprintf("%s (@@%s)", data.Message, data.Id)
 	}
 
 	// create new "ghost" user

--- a/matterircd.toml.example
+++ b/matterircd.toml.example
@@ -121,6 +121,9 @@ SuffixContext = false
 #in your mattermost "word that trigger mentions" notifications.
 ShowMentions = false
 
+#Enable support for replying to threads
+ThreadSupport = false
+
 #############################
 ##### SLACK EXAMPLE #########
 #############################

--- a/mm-go-irckit/server_commands.go
+++ b/mm-go-irckit/server_commands.go
@@ -487,7 +487,8 @@ func parseThreadID(u *User, msg *irc.Message, channelID string) (string, string)
 		if len(matches) == 2 {
 			msg.Trailing = strings.Replace(msg.Trailing, matches[0], "", 1)
 			parentID := matches[1]
-			return parentID, msg.Trailing
+			// Also strip separator in message.
+			return parentID, msg.Trailing[1:]
 		}
 	}
 

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -356,9 +356,15 @@ func (u *User) handleReactionEvent(event interface{}) {
 		reaction = e.Reaction
 	}
 
+	reactionText := text + reaction
+	if u.v.GetBool(u.br.Protocol() + ".threadsupport") {
+		messageIDString := fmt.Sprintf(" (@@%s)", messageID)
+		reactionText = text + reaction + messageIDString
+	}
+
 	if channelType == "D" {
 		e := &bridge.DirectMessageEvent{
-			Text:      text + reaction,
+			Text:      reactionText,
 			ChannelID: channelID,
 			Receiver:  u.UserInfo,
 			Sender:    sender,
@@ -372,7 +378,7 @@ func (u *User) handleReactionEvent(event interface{}) {
 	}
 
 	e := &bridge.ChannelMessageEvent{
-		Text:        text + reaction,
+		Text:        reactionText,
 		ChannelID:   channelID,
 		ChannelType: channelType,
 		Sender:      sender,

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -575,7 +575,15 @@ func (u *User) addUserToChannelWorker(channels <-chan *bridge.ChannelInfo, throt
 					prevDate = shortdate
 				}
 
-				spoof(nick, fmt.Sprintf("[%s] %s", ts.Format("15:04"), post))
+				threadIDString := ""
+				if u.v.GetBool(u.br.Protocol() + ".threadsupport") {
+					threadID := p.Id
+					if p.ParentId != "" {
+						threadID = p.ParentId
+					}
+					threadIDString = fmt.Sprintf(" (@@%s)", threadID)
+				}
+				spoof(nick, fmt.Sprintf("[%s] %s%s", ts.Format("15:04"), post, threadIDString))
 			}
 		}
 


### PR DESCRIPTION
This adds basic and lightweight threading support, which means showing parent post / thread ID when present and support for replying to thread. With this, if given a post ID (e.g. ${URL}/pl/wdtrfo13p3yozq479n3coafzpy), you can reply to older threads / posts.

```
|11:53 <hloeung> Testing new thread support
|11:53 <hloeung> Testing reply to thread (re @hloeung (@@fkd7r1hhypgyzmaztrwuerf4pr))
|11:53 <hloeung> @@fkd7r1hhypgyzmaztrwuerf4pr Testing reply from IRC ^ last one was from web UI
|11:53 <hloeung> @@fkd7r1hhypgyzmaztrwuerf4ps Testing invalid parent post
```

![TA7iQNC5](https://user-images.githubusercontent.com/95021/93594904-0b015b80-f9fa-11ea-908e-d3221e48bd86.png)
