### PR TITLE
add ShortenReplies

### DIFF
--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -678,7 +678,7 @@ func (m *Mattermost) wsActionPostSkip(rmsg *model.WebSocketEvent) bool {
 	return false
 }
 
-func maybeShorten(msg string, newLen int) string {
+func maybeShorten(msg string, newLen int, uncounted string) string {
 	if newLen == 0 || len(msg) < newLen {
 		return msg
 	}
@@ -690,6 +690,9 @@ func maybeShorten(msg string, newLen int) string {
 		}
 		if len(newMsg) < newLen {
 			newMsg = fmt.Sprintf("%s %s", newMsg, word)
+			if uncounted != "" && strings.HasPrefix(word, uncounted) {
+				newLen += len(word) + 1
+			}
 			continue
 		}
 		break
@@ -719,7 +722,7 @@ func (m *Mattermost) handleWsActionPost(rmsg *model.WebSocketEvent) {
 			if m.v.GetBool("mattermost.HideReplies") || m.v.GetBool("mattermost.prefixContext") || m.v.GetBool("mattermost.suffixContext") {
 				data.Message = fmt.Sprintf("%s (re @%s)", data.Message, parentGhost.Nick)
 			} else {
-				parentMessage := maybeShorten(parentPost.Message, m.v.GetInt("mattermost.ShortenRepliesTo"))
+				parentMessage := maybeShorten(parentPost.Message, m.v.GetInt("mattermost.ShortenRepliesTo"), "@")
 				data.Message = fmt.Sprintf("%s (re @%s: %s)", data.Message, parentGhost.Nick, parentMessage)
 			}
 		}

--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -692,14 +692,22 @@ func maybeShorten(msg string, newLen int, uncounted string) string {
 			continue
 		}
 		if len(newMsg) < newLen {
-			newMsg = fmt.Sprintf("%s %s", newMsg, word)
+			skipped := false
 			if uncounted != "" && strings.HasPrefix(word, uncounted) {
 				newLen += len(word) + 1
+				skipped = true
 			}
+			// Truncate very long words, but only if they were not skipped, on the
+			// assumption that such words are important enough to be preserved whole.
+			if !skipped && len(word) > newLen {
+				word = fmt.Sprintf("%s[...]", word[0:(newLen*2/3)])
+			}
+			newMsg = fmt.Sprintf("%s %s", newMsg, word)
 			continue
 		}
 		break
 	}
+
 	return fmt.Sprintf("%s ...", newMsg)
 }
 

--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -678,6 +678,9 @@ func (m *Mattermost) wsActionPostSkip(rmsg *model.WebSocketEvent) bool {
 	return false
 }
 
+// maybeShorten returns a prefix of msg that is approximately newLen
+// characters long, followed by "...".  Words that start with uncounted
+// are included in the result but are not reckoned against newLen.
 func maybeShorten(msg string, newLen int, uncounted string) string {
 	if newLen == 0 || len(msg) < newLen {
 		return msg

--- a/matterircd.toml.example
+++ b/matterircd.toml.example
@@ -105,8 +105,8 @@ PreferNickname = false
 # Disable showing parent post / replies
 HideReplies = false
 
-# Shorten replies
-ShortenReplies = false
+# Shorten replies to approximately this length
+ShortenRepliesTo = 0
 
 #Only join direct/group messages when someone talks. This stops from cluttering your 
 #irc client with lots of windows.

--- a/matterircd.toml.example
+++ b/matterircd.toml.example
@@ -105,6 +105,9 @@ PreferNickname = false
 # Disable showing parent post / replies
 HideReplies = false
 
+# Shorten replies
+ShortenReplies = false
+
 #Only join direct/group messages when someone talks. This stops from cluttering your 
 #irc client with lots of windows.
 #If set to true dm/group messages will be joined on startup and not only on talk in the channel.


### PR DESCRIPTION
This makes busy reply threads on long messages more tolerable, in my brief experience.

The length limit is entirely arbitrary and could be made configurable.

Example:

```
<pjdc> `To build Emacs with xwidgets support, you will need to install
       the webkit2gtk-4.0 package; version 2.12 or later is required. (This
       change was actually made in Emacs 26.1, but was not called out in its
       NEWS.)`
<pjdc> just one more reply test, eh? (re @pjdc: `To build Emacs with ...)
```