### PR TITLE
UserBridge: lock updateCounter against concurrent updates

### DIFF
--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -19,14 +19,15 @@ import (
 )
 
 type UserBridge struct {
-	Srv           Server
-	Credentials   bridge.Credentials
-	br            bridge.Bridger // nolint:structcheck
-	inprogress    bool           //nolint:structcheck
-	msgMap        map[string]map[string]int
-	msgCounter    map[string]int       //nolint:structcheck
-	msgMapMutex   sync.RWMutex         //nolint:structcheck
-	updateCounter map[string]time.Time //nolint:structcheck
+	Srv                Server
+	Credentials        bridge.Credentials
+	br                 bridge.Bridger //nolint:structcheck
+	inprogress         bool           //nolint:structcheck
+	msgMap             map[string]map[string]int
+	msgCounter         map[string]int       //nolint:structcheck
+	msgMapMutex        sync.RWMutex         //nolint:structcheck
+	updateCounter      map[string]time.Time //nolint:structcheck
+	updateCounterMutex sync.Mutex           //nolint:structcheck
 }
 
 func NewUserBridge(c net.Conn, srv Server, cfg *viper.Viper) *User {
@@ -808,6 +809,8 @@ func (u *User) prefixContext(channelID, messageID, parentID, event string) strin
 }
 
 func (u *User) updateLastViewed(channelID string) {
+	u.updateCounterMutex.Lock()
+	defer u.updateCounterMutex.Unlock()
 	if t, ok := u.updateCounter[channelID]; ok {
 		if time.Since(t) < time.Second*5 {
 			return


### PR DESCRIPTION
Add updateCounterMutex, which should prevent the crash below (the rest of the relevant goroutines can be seen in https://paste.ubuntu.com/p/H4Xy9DZmWs/):

```
fatal error: concurrent map writes

goroutine 43950 [running]:
runtime.throw(0x99b098, 0x15)
        /snap/go/6439/src/runtime/panic.go:1116 +0x72 fp=0xc001133d68 sp=0xc001133d38 pc=0x439012
runtime.mapassign_faststr(0x8ec060, 0xc0002554a0, 0xc000c2c380, 0x1a, 0xc00093d8d0)
        /snap/go/6439/src/runtime/map_faststr.go:211 +0x3f1 fp=0xc001133dd0 sp=0xc001133d68 pc=0x4162f1
github.com/42wim/matterircd/mm-go-irckit.(*User).updateLastViewed(0xc000144500, 0xc000c2c380, 0x1a)
        /home/paul/go/src/github.com/42wim/matterircd/mm-go-irckit/userbridge.go:817 +0xc8 fp=0xc001133e28 sp=0xc001133dd0 pc=0x86b528
github.com/42wim/matterircd/mm-go-irckit.(*User).addUserToChannelWorker(0xc000144500, 0xc000dda900, 0xc000093a90)
        /home/paul/go/src/github.com/42wim/matterircd/mm-go-irckit/userbridge.go:583 +0x9a5 fp=0xc001133fc8 sp=0xc001133e28 pc=0x868585
runtime.goexit()
        /snap/go/6439/src/runtime/asm_amd64.s:1374 +0x1 fp=0xc001133fd0 sp=0xc001133fc8 pc=0x470f81
created by github.com/42wim/matterircd/mm-go-irckit.(*User).addUsersToChannels
        /home/paul/go/src/github.com/42wim/matterircd/mm-go-irckit/userbridge.go:480 +0x332
```