### PR TITLE
Fix missing botname and fix attachments without text

### DIFF
--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -664,6 +664,7 @@ func (s *Slack) getSlackUserFromMessage(rmsg *slack.MessageEvent) (*slack.User, 
 				LastName:  "bot",
 				RealName:  "bot",
 			},
+			Name: rmsg.Username,
 		}
 
 		if rmsg.Username == "" {
@@ -768,6 +769,7 @@ func (s *Slack) handleSlackActionPost(rmsg *slack.MessageEvent) {
 	for _, attach := range rmsg.Attachments {
 		if attach.Pretext != "" {
 			msgs = append(msgs, strings.Split(attach.Pretext, "\n")...)
+			msghandled = true
 		}
 
 		if attach.Text == "" {


### PR DESCRIPTION
If bot sets the username in the message it was not being used. For example slack-irc bridge uses this.

If message contained only pretext without actual text it was not marked as handled and thus whole details were shown. For example Zendesk ticket notifications sometimes contain only pretext.