### PR TITLE
Thread support2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+matterircd
 matterircd.toml

--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -323,6 +323,14 @@ func (m *Mattermost) MsgChannelThread(channelID, parentID, text string) (string,
 	props := make(map[string]interface{})
 	props["matterircd_"+m.mc.User.Id] = true
 
+	if parentID != "" {
+		_, resp := m.mc.Client.GetPost(parentID, "")
+		if resp.Error != nil {
+			logger.Errorf("Unable to get parent post %s", parentID)
+			parentID = ""
+		}
+	}
+
 	post := &model.Post{
 		ChannelId: channelID,
 		Message:   text,

--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -323,14 +323,6 @@ func (m *Mattermost) MsgChannelThread(channelID, parentID, text string) (string,
 	props := make(map[string]interface{})
 	props["matterircd_"+m.mc.User.Id] = true
 
-	if parentID != "" {
-		_, resp := m.mc.Client.GetPost(parentID, "")
-		if resp.Error != nil {
-			logger.Errorf("Unable to get parent post %s", parentID)
-			parentID = ""
-		}
-	}
-
 	post := &model.Post{
 		ChannelId: channelID,
 		Message:   text,

--- a/mm-go-irckit/server_commands.go
+++ b/mm-go-irckit/server_commands.go
@@ -507,6 +507,20 @@ func parseThreadID(u *User, msg *irc.Message, channelID string) (string, string)
 		}
 	}
 
+	re = regexp.MustCompile(`^\@\@([0-9a-z]{26})`)
+	matches = re.FindStringSubmatch(msg.Trailing)
+
+	if len(matches) == 2 {
+		msg.Trailing = strings.Replace(msg.Trailing, matches[0], "", 1)
+		parentID := matches[1]
+		newMessage := msg.Trailing
+		// Also strip separator in message.
+		if len(newMessage) > 1 {
+			newMessage = newMessage[1:]
+		}
+		return parentID, newMessage
+	}
+
 	return "", ""
 }
 


### PR DESCRIPTION
Per https://github.com/42wim/matterircd/pull/320, split out support for replying to older threads using parent/post ID.

10:59 <hloeung> @@epjhhxi3fpd33kb7usmyfuza6r testing replying to old thread
11:00 <hloeung> @@epjhhxi3fpd33kb7usmyfuza6c testing replying to invalid thread
11:00 <hloeung> @@epjhhxi3fpd33kb7usmyfuza6r
11:00 <hloeung> @@epjhhxi3fpd33kb7usmyfuza6rabc

![WEI0lHdNNR](https://user-images.githubusercontent.com/95021/97819648-0371e980-1cfe-11eb-87e6-19236149bbb4.png)
