### PR TITLE
Allow showing parent thread or message ID with PrefixContext / SuffixContext

### DIFF
--- a/matterircd.toml.example
+++ b/matterircd.toml.example
@@ -124,8 +124,8 @@ PrefixContext = false
 # Same as PrefixContext but with the message context at the end.
 SuffixContext = false
 # If either PrefixContext or SuffixContext specify which thread ID to use. Default is the
-# matterircd generated. Uncomment to use parent ID instead.
-#ThreadContext = "parentid"
+# matterircd generated @@([0-9][a-f]){3}. Uncomment to use Mattermost's message/parent thread IDs instead.
+#ThreadContext = "mattermost"
 
 #This will show (mention yournick) after a message if it contains one of the words configured
 #in your mattermost "word that trigger mentions" notifications.

--- a/matterircd.toml.example
+++ b/matterircd.toml.example
@@ -123,6 +123,9 @@ JoinDM = false
 PrefixContext = false
 # Same as PrefixContext but with the message context at the end.
 SuffixContext = false
+# If either PrefixContext or SuffixContext specify which thread ID to use. Default is the
+# matterircd generated. Uncomment to use parent ID instead.
+#ThreadContext = "parentid"
 
 #This will show (mention yournick) after a message if it contains one of the words configured
 #in your mattermost "word that trigger mentions" notifications.

--- a/mm-go-irckit/server_commands.go
+++ b/mm-go-irckit/server_commands.go
@@ -484,9 +484,21 @@ func parseModifyMsg(u *User, msg *irc.Message, channelID string) bool {
 }
 
 func parseThreadID(u *User, msg *irc.Message, channelID string) (string, string) {
-	re := regexp.MustCompile(`^\@\@([0-9a-f]{3})`)
+	re := regexp.MustCompile(`^\@\@([0-9a-z]{26})`)
 	matches := re.FindStringSubmatch(msg.Trailing)
+	if len(matches) == 2 {
+		msg.Trailing = strings.Replace(msg.Trailing, matches[0], "", 1)
+		parentID := matches[1]
+		newMessage := msg.Trailing
+		// Also strip separator in message.
+		if len(newMessage) > 1 {
+			newMessage = newMessage[1:]
+		}
+		return parentID, newMessage
+	}
 
+	re = regexp.MustCompile(`^\@\@([0-9a-f]{3})`)
+	matches = re.FindStringSubmatch(msg.Trailing)
 	if len(matches) == 2 {
 		msg.Trailing = strings.Replace(msg.Trailing, matches[0], "", 1)
 
@@ -505,20 +517,6 @@ func parseThreadID(u *User, msg *irc.Message, channelID string) (string, string)
 				return k, msg.Trailing
 			}
 		}
-	}
-
-	re = regexp.MustCompile(`^\@\@([0-9a-z]{26})`)
-	matches = re.FindStringSubmatch(msg.Trailing)
-
-	if len(matches) == 2 {
-		msg.Trailing = strings.Replace(msg.Trailing, matches[0], "", 1)
-		parentID := matches[1]
-		newMessage := msg.Trailing
-		// Also strip separator in message.
-		if len(newMessage) > 1 {
-			newMessage = newMessage[1:]
-		}
-		return parentID, newMessage
 	}
 
 	return "", ""

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -774,6 +774,14 @@ func (u *User) prefixContextModified(channelID, messageID string) string {
 }
 
 func (u *User) prefixContext(channelID, messageID, parentID, event string) string {
+	if u.v.GetString(u.br.Protocol()+".threadcontext") == "parentid" {
+		threadID := messageID
+		if parentID != "" {
+			threadID = parentID
+		}
+		return fmt.Sprintf("[@@%s]", threadID)
+	}
+
 	u.msgMapMutex.Lock()
 	defer u.msgMapMutex.Unlock()
 

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -582,7 +582,7 @@ func (u *User) addUserToChannelWorker(channels <-chan *bridge.ChannelInfo, throt
 					prevDate = shortdate
 				}
 
-				if u.v.GetString(u.br.Protocol()+".threadcontext") == "parentid" {
+				if u.v.GetString(u.br.Protocol()+".threadcontext") == "mattermost" {
 					threadID := p.Id
 					if p.ParentId != "" {
 						threadID = p.ParentId
@@ -788,7 +788,7 @@ func (u *User) prefixContextModified(channelID, messageID string) string {
 }
 
 func (u *User) prefixContext(channelID, messageID, parentID, event string) string {
-	if u.v.GetString(u.br.Protocol()+".threadcontext") == "parentid" {
+	if u.v.GetString(u.br.Protocol()+".threadcontext") == "mattermost" {
 		threadID := messageID
 		if parentID != "" {
 			threadID = parentID

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -582,7 +582,21 @@ func (u *User) addUserToChannelWorker(channels <-chan *bridge.ChannelInfo, throt
 					prevDate = shortdate
 				}
 
-				spoof(nick, fmt.Sprintf("[%s] %s", ts.Format("15:04"), post))
+				if u.v.GetString(u.br.Protocol()+".threadcontext") == "parentid" {
+					threadID := p.Id
+					if p.ParentId != "" {
+						threadID = p.ParentId
+					}
+
+					switch {
+					case u.v.GetBool(u.br.Protocol() + ".prefixcontext"):
+						spoof(nick, fmt.Sprintf("[%s] [@@%s] %s", ts.Format("15:04"), threadID, post))
+					case u.v.GetBool(u.br.Protocol() + ".suffixcontext"):
+						spoof(nick, fmt.Sprintf("[%s] %s [@@%s]", ts.Format("15:04"), post, threadID))
+					}
+				} else {
+					spoof(nick, fmt.Sprintf("[%s] %s", ts.Format("15:04"), post))
+				}
 			}
 		}
 


### PR DESCRIPTION
Per https://github.com/42wim/matterircd/pull/344#issuecomment-733971333, this adds an option, ThreadContext="mattermost", to show the Mattermost's internal message or parent thread ID rather than the matterircd generated 3-letter hexadecimal counter (the default).

This can be used to reply to threads or create threads replying to messages.

With SuffixContext:

    |19:33 <hloeung> added reaction: coffee [@@mbqq5nsgm3ypmx5befzm5y4bgh]
    |19:34 <hloeung> :coffee: [@@zyo6u9ew1jgo5jnj85erxruakc]

With PrefixContext:

    |19:39 <hloeung> [@@3u9tojwo1ib89j7m39riykjy3a] Test
    |19:39 <hloeung> [@@mbqq5nsgm3ypmx5befzm5y4bgh] added reaction: 100
