### PR TITLE
Fix missing replay when ThreadContext set but not PrefixContext/SuffixContext

### DIFF
--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -582,6 +582,7 @@ func (u *User) addUserToChannelWorker(channels <-chan *bridge.ChannelInfo, throt
 					prevDate = shortdate
 				}
 
+				replayMsg := fmt.Sprintf("[%s] %s", ts.Format("15:04"), post)
 				if u.v.GetString(u.br.Protocol()+".threadcontext") == "mattermost" {
 					threadID := p.Id
 					if p.ParentId != "" {
@@ -590,13 +591,12 @@ func (u *User) addUserToChannelWorker(channels <-chan *bridge.ChannelInfo, throt
 
 					switch {
 					case u.v.GetBool(u.br.Protocol() + ".prefixcontext"):
-						spoof(nick, fmt.Sprintf("[%s] [@@%s] %s", ts.Format("15:04"), threadID, post))
+						replayMsg = fmt.Sprintf("[%s] [@@%s] %s", ts.Format("15:04"), threadID, post)
 					case u.v.GetBool(u.br.Protocol() + ".suffixcontext"):
-						spoof(nick, fmt.Sprintf("[%s] %s [@@%s]", ts.Format("15:04"), post, threadID))
+						replayMsg = fmt.Sprintf("[%s] %s [@@%s]", ts.Format("15:04"), post, threadID)
 					}
-				} else {
-					spoof(nick, fmt.Sprintf("[%s] %s", ts.Format("15:04"), post))
 				}
+				spoof(nick, replayMsg)
 			}
 		}
 


### PR DESCRIPTION
If ThreadContext is set, but neither PrefixContext or SuffixContext, then no replay messages.