### PR TITLE
Allow modifying or deleting last message and by Mattermost message ID

### DIFF
--- a/mm-go-irckit/server_commands.go
+++ b/mm-go-irckit/server_commands.go
@@ -409,7 +409,7 @@ func CmdPrivMsg(s Server, u *User, msg *irc.Message) error {
 			if u.br == nil {
 				return nil
 			}
-			if threadMsgUser(u, toUser.User, msg) {
+			if threadMsgUser(u, msg, toUser.User) {
 				return nil
 			}
 
@@ -566,10 +566,14 @@ func threadMsgChannel(u *User, msg *irc.Message, channelID string) bool {
 		u.msgLast[channelID] = msgID
 	}
 
+	if u.v.GetBool(u.br.Protocol()+".prefixcontext") || u.v.GetBool(u.br.Protocol()+".suffixcontext") {
+		u.prefixContext(channelID, msgID, "", "")
+	}
+
 	return true
 }
 
-func threadMsgUser(u *User, toUser string, msg *irc.Message) bool {
+func threadMsgUser(u *User, msg *irc.Message, toUser string) bool {
 	msgID, text := parseThreadID(u, msg, toUser)
 	if msgID == "" {
 		return false
@@ -582,6 +586,10 @@ func threadMsgUser(u *User, toUser string, msg *irc.Message) bool {
 		u.msgLastMutex.Lock()
 		defer u.msgLastMutex.Unlock()
 		u.msgLast[toUser] = msgID
+	}
+
+	if u.v.GetBool(u.br.Protocol()+".prefixcontext") || u.v.GetBool(u.br.Protocol()+".suffixcontext") {
+		u.prefixContext(toUser, msgID, "", "")
 	}
 
 	return true

--- a/mm-go-irckit/server_commands.go
+++ b/mm-go-irckit/server_commands.go
@@ -471,6 +471,9 @@ func parseModifyMsg(u *User, msg *irc.Message, channelID string) bool {
 	// Mattermost message/thread ID (e.g. 'cfrakpwix7y8pgzux6ta76pm9c')
 	case len(matches[1]) == 28:
 		msgID = strings.ReplaceAll(matches[1], "/", "")
+		u.msgLastMutex.Lock()
+		defer u.msgLastMutex.Unlock()
+		u.msgLast[channelID] = msgID
 	// matterircd message/thread ID (e.g. '004' and 'a12')
 	case len(matches[1]) == 5:
 		id, err := strconv.ParseInt(strings.ReplaceAll(matches[1], "/", ""), 16, 0)
@@ -486,6 +489,9 @@ func parseModifyMsg(u *User, msg *irc.Message, channelID string) bool {
 		for k, v := range m {
 			if v == int(id) {
 				msgID = k
+				u.msgLastMutex.Lock()
+				defer u.msgLastMutex.Unlock()
+				u.msgLast[channelID] = msgID
 			}
 		}
 	}

--- a/mm-go-irckit/server_commands.go
+++ b/mm-go-irckit/server_commands.go
@@ -386,12 +386,11 @@ func CmdPrivMsg(s Server, u *User, msg *irc.Message) error {
 			u.MsgSpoofUser(u, u.br.Protocol(), "msg: "+msg.Trailing+" could not be send: "+err2.Error())
 			return err2
 		}
-		
+
 		u.msgLastMutex.Lock()
 		defer u.msgLastMutex.Unlock()
-		
+
 		u.msgLast[ch.ID()] = msgID
-		}
 
 		if u.v.GetBool(u.br.Protocol()+".prefixcontext") || u.v.GetBool(u.br.Protocol()+".suffixcontext") {
 			u.prefixContext(ch.ID(), msgID, "", "")
@@ -467,7 +466,7 @@ func parseModifyMsg(u *User, msg *irc.Message, channelID string) bool {
 	case matches[1] == "//" || matches[1] == "/!!/":
 		u.msgLastMutex.RLock()
 		defer u.msgLastMutex.RUnlock()
-		if msgLast, ok := u.msgLast[channelID];ok {
+		if msgLast, ok := u.msgLast[channelID]; ok {
 			msgID = msgLast
 		}
 	// Mattermost message/thread ID (e.g. 'cfrakpwix7y8pgzux6ta76pm9c')
@@ -492,12 +491,12 @@ func parseModifyMsg(u *User, msg *irc.Message, channelID string) bool {
 			if v != int(id) {
 				continue
 			}
-			
+
 			msgID = k
-			
+
 			u.msgLastMutex.Lock()
 			defer u.msgLastMutex.Unlock()
-			
+
 			u.msgLast[channelID] = msgID
 		}
 	}
@@ -571,7 +570,7 @@ func threadMsgChannel(u *User, msg *irc.Message, channelID string) bool {
 
 	u.msgLastMutex.Lock()
 	defer u.msgLastMutex.Unlock()
-	
+
 	u.msgLast[channelID] = msgID
 
 	if u.v.GetBool(u.br.Protocol()+".prefixcontext") || u.v.GetBool(u.br.Protocol()+".suffixcontext") {
@@ -592,10 +591,10 @@ func threadMsgUser(u *User, msg *irc.Message, toUser string) bool {
 		u.MsgSpoofUser(u, u.br.Protocol(), "msg: "+text+" could not be send: "+err.Error())
 		return false
 	}
-	
+
 	u.msgLastMutex.Lock()
 	defer u.msgLastMutex.Unlock()
-	
+
 	u.msgLast[toUser] = msgID
 
 	if u.v.GetBool(u.br.Protocol()+".prefixcontext") || u.v.GetBool(u.br.Protocol()+".suffixcontext") {

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -24,6 +24,7 @@ type UserBridge struct {
 	br                 bridge.Bridger    //nolint:structcheck
 	inprogress         bool              //nolint:structcheck
 	msgLast            map[string]string //nolint:structcheck
+	msgLastMutex       sync.RWMutex      //nolint:structcheck
 	msgMap             map[string]map[string]int
 	msgCounter         map[string]int       //nolint:structcheck
 	msgMapMutex        sync.RWMutex         //nolint:structcheck

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -21,8 +21,9 @@ import (
 type UserBridge struct {
 	Srv                Server
 	Credentials        bridge.Credentials
-	br                 bridge.Bridger //nolint:structcheck
-	inprogress         bool           //nolint:structcheck
+	br                 bridge.Bridger    //nolint:structcheck
+	inprogress         bool              //nolint:structcheck
+	msgLast            map[string]string //nolint:structcheck
 	msgMap             map[string]map[string]int
 	msgCounter         map[string]int       //nolint:structcheck
 	msgMapMutex        sync.RWMutex         //nolint:structcheck
@@ -39,6 +40,7 @@ func NewUserBridge(c net.Conn, srv Server, cfg *viper.Viper) *User {
 
 	u.Srv = srv
 	u.v = cfg
+	u.msgLast = make(map[string]string)
 	u.msgMap = make(map[string]map[string]int)
 	u.msgCounter = make(map[string]int)
 	u.updateCounter = make(map[string]time.Time)

--- a/prefixcontext.md
+++ b/prefixcontext.md
@@ -87,3 +87,16 @@ To delete the message just set the newtext empty `s/number/`
 23:25 < wimirc> s/003/hello how are you
 23:25 <@wim> [004] fine
 ```
+
+You can also modify or delete the last message you sent.
+
+```irc
+23:25 <@wim> [001] hi
+23:25 <@wim> [002] something
+23:25 < wimirc> hllo how are you
+23:25 < wimirc> s//hello how are you
+23:25 < wimirc> s/!!/hello, how are you?
+23:25 <@wim> [004] fine
+23:25 < wimirc> good
+23:25 < wimirc> s//
+```


### PR DESCRIPTION
Store the Mattermost message ID of the most recent message sent to channel. With that, we can use 'last' to modify or delete. e.g.

|21:15 <hloeung> Test
|21:15 <hloeung> s//Update last test message
|21:15 <hloeung> s//

Also add support for modifying messages using the Mattermost message ID. e.g.

|21:14 <hloeung> Test [@@o5ctj8u3qfgtxf5icisewtdyty]
|21:14 <hloeung> s/o5ctj8u3qfgtxf5icisewtdyty/Update
|21:14 <hloeung> Update (edited) [@@o5ctj8u3qfgtxf5icisewtdyty]
|21:14 <hloeung> s/o5ctj8u3qfgtxf5icisewtdyty/
|21:14 <hloeung> Update (deleted) [@@o5ctj8u3qfgtxf5icisewtdyty]