### PR TITLE
Save last viewed at state and use for replaying logs

### DIFF
--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -23,6 +23,8 @@ type UserBridge struct {
 	Credentials        bridge.Credentials
 	br                 bridge.Bridger    //nolint:structcheck
 	inprogress         bool              //nolint:structcheck
+	lastViewedAt       map[string]int64  //nolint:structcheck
+	lastViewedAtMutex  sync.RWMutex      //nolint:structcheck
 	msgLast            map[string]string //nolint:structcheck
 	msgLastMutex       sync.RWMutex      //nolint:structcheck
 	msgMap             map[string]map[string]int
@@ -147,6 +149,9 @@ func (u *User) handleDirectMessageEvent(event *bridge.DirectMessageEvent) {
 	if !u.v.GetBool(u.br.Protocol() + ".disableautoview") {
 		u.updateLastViewed(event.ChannelID)
 	}
+	u.lastViewedAtMutex.Lock()
+	defer u.lastViewedAtMutex.Unlock()
+	u.lastViewedAt[event.ChannelID] = model.GetMillis()
 }
 
 func (u *User) handleChannelAddEvent(event *bridge.ChannelAddEvent) {
@@ -170,6 +175,9 @@ func (u *User) handleChannelAddEvent(event *bridge.ChannelAddEvent) {
 	if !u.v.GetBool(u.br.Protocol() + ".disableautoview") {
 		u.updateLastViewed(event.ChannelID)
 	}
+	u.lastViewedAtMutex.Lock()
+	defer u.lastViewedAtMutex.Unlock()
+	u.lastViewedAt[event.ChannelID] = model.GetMillis()
 }
 
 func (u *User) handleChannelRemoveEvent(event *bridge.ChannelRemoveEvent) {
@@ -275,6 +283,9 @@ func (u *User) handleChannelMessageEvent(event *bridge.ChannelMessageEvent) {
 	if !u.v.GetBool(u.br.Protocol() + ".disableautoview") {
 		u.updateLastViewed(event.ChannelID)
 	}
+	u.lastViewedAtMutex.Lock()
+	defer u.lastViewedAtMutex.Unlock()
+	u.lastViewedAt[event.ChannelID] = model.GetMillis()
 }
 
 func (u *User) handleFileEvent(event *bridge.FileEvent) {
@@ -536,6 +547,12 @@ func (u *User) addUserToChannelWorker(channels <-chan *bridge.ChannelInfo, throt
 		if since == 0 {
 			continue
 		}
+		// We used to stored last viewed at if present.
+		u.lastViewedAtMutex.RLock()
+		defer u.lastViewedAtMutex.RUnlock()
+		if lastViewedAt, ok := u.lastViewedAt[brchannel.ID]; ok {
+			since = lastViewedAt
+		}
 		// post everything to the channel you haven't seen yet
 		postlist := u.br.GetPostsSince(brchannel.ID, since)
 		if postlist == nil {
@@ -606,6 +623,9 @@ func (u *User) addUserToChannelWorker(channels <-chan *bridge.ChannelInfo, throt
 		if !u.v.GetBool(u.br.Protocol() + ".disableautoview") {
 			u.updateLastViewed(brchannel.ID)
 		}
+		u.lastViewedAtMutex.Lock()
+		defer u.lastViewedAtMutex.Unlock()
+		u.lastViewedAt[brchannel.ID] = model.GetMillis()
 	}
 }
 

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -43,6 +43,7 @@ func NewUserBridge(c net.Conn, srv Server, cfg *viper.Viper) *User {
 
 	u.Srv = srv
 	u.v = cfg
+	u.lastViewedAt = make(map[string]int64)
 	u.msgLast = make(map[string]string)
 	u.msgMap = make(map[string]map[string]int)
 	u.msgCounter = make(map[string]int)

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -549,10 +549,10 @@ func (u *User) addUserToChannelWorker(channels <-chan *bridge.ChannelInfo, throt
 		}
 		// We used to stored last viewed at if present.
 		u.lastViewedAtMutex.RLock()
-		defer u.lastViewedAtMutex.RUnlock()
 		if lastViewedAt, ok := u.lastViewedAt[brchannel.ID]; ok {
 			since = lastViewedAt
 		}
+		u.lastViewedAtMutex.RUnlock()
 		// post everything to the channel you haven't seen yet
 		postlist := u.br.GetPostsSince(brchannel.ID, since)
 		if postlist == nil {
@@ -624,8 +624,8 @@ func (u *User) addUserToChannelWorker(channels <-chan *bridge.ChannelInfo, throt
 			u.updateLastViewed(brchannel.ID)
 		}
 		u.lastViewedAtMutex.Lock()
-		defer u.lastViewedAtMutex.Unlock()
 		u.lastViewedAt[brchannel.ID] = model.GetMillis()
+		u.lastViewedAtMutex.Unlock()
 	}
 }
 

--- a/pkg/matterclient/matterclient.go
+++ b/pkg/matterclient/matterclient.go
@@ -366,8 +366,7 @@ func (m *Client) doLogin(firstConnection bool, b *backoff.Backoff) error {
 			if err != nil {
 				return err
 			}
-		}
-		if m.Credentials.MFAToken != "" {
+		} else if m.Credentials.MFAToken != "" {
 			user, resp = m.Client.LoginWithMFA(m.Credentials.Login, m.Credentials.Pass, m.Credentials.MFAToken)
 		} else {
 			user, resp = m.Client.Login(m.Credentials.Login, m.Credentials.Pass)


### PR DESCRIPTION
Per https://github.com/42wim/matterircd/issues/245, we can't trust that Mattermost has updated the last viewed for channel. Instead, we save this locally and use that for replaying of logs. Useful for when experiencing flaky network causing matterircd to reconnect.

This is also part of https://github.com/42wim/matterircd/issues/313, we can dump this out to disk and read/load on start up.

With testing on my laptop, suspend, then resume. Adding print logging on line 555 (`logger.Info("Using last saved for channel %s ", brchannel.ID, lastViewedAt)`):

    [0194] ERROR matterclient: connection not alive: NewWebSocketClient: model.websocket_client.connect_fail.app_error, read tcp 192.168.1.23:42334->xxx.xxx.xxx.xxx:443: read: connection reset by peer
    [0204] ERROR matterclient: got a listen error: &model.AppError{Id:"model.websocket_client.connect_fail.app_error", Message:"model.websocket_client.connect_fail.app_error", DetailedError:"read tcp 192.168.1.23:42334->xxx.xxx.xxx.xxx:443: read: connection reset by peer", RequestId:"", StatusCode:500, Where:"NewWebSocketClient", IsOAuth:false, params:map[string]interface {}(nil)}
    [0204]  INFO matterclient: reconnect: logout
    [0204]  INFO matterclient: reconnect: login
    [0205]  INFO matterclient: Found version 5.27.0.5.27.0.3bd4fc983a4aa622183c3bd1e77029e0.true
    [0211]  INFO matterclient: found xxx users in team myteam
    [0213]  INFO matterclient: reconnect successful
    INFO[2020-12-13T09:25:21+11:00] Using last saved for channel %symnb5h6ubifuiymzntyumqtgae 1607811527343  module=matterircd

Then again, but with a message waiting:

    |09:19 -!- Irssi: Join to #haw-test was synced in 39 secs
    |09:46 <matterircd> Replaying since 2020-12-13 09:46:26
    |09:46 <hloeung> [09:46] Test replay backlog  [@@zy7t6us9c3fn8yywj3cmp4mb8e]

With no old and repeated replay logs from any of the channels I'm in.