### PR TITLE
Logging with timestamp

### DIFF
--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -32,6 +32,7 @@ func New(v *viper.Viper, cred bridge.Credentials, eventChan chan *bridge.Event, 
 		v:           v,
 	}
 
+	logger.SetFormatter(&logger.TextFormatter{FullTimestamp: true})
 	if v.GetBool("debug") {
 		logger.SetLevel(logger.DebugLevel)
 	}

--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -38,6 +38,7 @@ func New(v *viper.Viper, cred bridge.Credentials, eventChan chan *bridge.Event, 
 
 	var err error
 
+	logger.SetFormatter(&logger.TextFormatter{FullTimestamp: true})
 	if v.GetBool("debug") {
 		logger.SetLevel(logger.DebugLevel)
 	}

--- a/pkg/matterclient/matterclient.go
+++ b/pkg/matterclient/matterclient.go
@@ -83,6 +83,7 @@ func New(login string, pass string, team string, server string, mfatoken string)
 	rootLogger.SetFormatter(&prefixed.TextFormatter{
 		PrefixPadding: 13,
 		DisableColors: true,
+		FullTimestamp: true,
 	})
 
 	cred := &Credentials{


### PR DESCRIPTION
Some lines are logged without timestamps. e.g.

    INFO[2020-12-25T04:27:05Z] Running version 0.21.1-dev                    module=matterircd
    INFO[2020-12-25T04:27:05Z] WARNING: THIS IS A DEVELOPMENT VERSION. Things may break.  module=matterircd
    INFO[2020-12-25T04:27:05Z] Listening on 127.0.0.1:6697                   module=matterircd
    INFO[2020-12-25T04:28:01Z] New connection: 127.0.0.1:52986               module=matterircd
    ...
    loggerlevel: info
    INFO[0066] login as hloeung (team: myteam) on mychat.mydomain
    [0066]  INFO matterclient: Found version 5.27.0.5.27.0.3bd4fc983a4aa622183c3bd1e77029e0.true
    [0070]  INFO matterclient: found 1111 users in team myteam
    INFO[0072] login succeeded

This makes it so the login lines as well as matterclient also log timestamp:

    loggerlevel: info
    INFO[2020-12-25T04:55:03Z] login as hloeung (team: myteam) on mychat.mydomain
    [2020-12-25T04:55:04Z]  INFO matterclient: Found version 5.27.0.5.27.0.3bd4fc983a4aa622183c3bd1e77029e0.true
    [2020-12-25T04:55:08Z]  INFO matterclient: found 1111 users in team myteam
    INFO[2020-12-25T04:55:10Z] login succeeded

This is also useful for logging matterclient INFO/ERROR lines such as:

    [56747]  INFO matterclient: reconnect: login
    [56757] ERROR matterclient: reconnect: login failed: ... context deadline exceeded (Client.Timeout exceeded while awaiting headers)", retrying in 10 seconds