### PR TITLE
Save lastViewedAt and load on start up (#313)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 matterircd
 matterircd.toml
+matterircd-lastsaved.db

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	version = "0.22.0"
+	version = "0.22.1-dev"
 	githash string
 	logger  *logrus.Entry
 	v       *viper.Viper

--- a/matterircd.toml.example
+++ b/matterircd.toml.example
@@ -132,6 +132,14 @@ SuffixContext = false
 #in your mattermost "word that trigger mentions" notifications.
 ShowMentions = false
 
+# Path to file to store last viewed information. This is useful for replying only
+# the messages missed.
+LastViewedSavePath = "matterircd-lastsaved.db"
+# Interval for how often to save last viewed information.
+LastViewedSaveInterval = "5m"
+# Consider saved last view information stale if saved town-square older than this time
+LastViewedStaleDuration = "30d"
+
 #############################
 ##### SLACK EXAMPLE #########
 #############################

--- a/matterircd.toml.example
+++ b/matterircd.toml.example
@@ -137,7 +137,7 @@ ShowMentions = false
 LastViewedSavePath = "matterircd-lastsaved.db"
 # Interval for how often to save last viewed information.
 LastViewedSaveInterval = "5m"
-# Consider saved last view information stale if saved town-square older than this time
+# Consider saved last view information stale if last saved older than this time
 LastViewedStaleDuration = "30d"
 
 #############################

--- a/matterircd.toml.example
+++ b/matterircd.toml.example
@@ -134,7 +134,7 @@ ShowMentions = false
 
 # Path to file to store last viewed information. This is useful for replying only
 # the messages missed.
-LastViewedSavePath = "matterircd-lastsaved.db"
+LastViewedSaveFile = "matterircd-lastsaved.db"
 # Interval for how often to save last viewed information.
 LastViewedSaveInterval = "5m"
 # Consider saved last view information stale if last saved older than this time

--- a/mm-go-irckit/server_commands.go
+++ b/mm-go-irckit/server_commands.go
@@ -389,8 +389,8 @@ func CmdPrivMsg(s Server, u *User, msg *irc.Message) error {
 
 		u.msgLastMutex.Lock()
 		defer u.msgLastMutex.Unlock()
-
 		u.msgLast[ch.ID()] = [2]string{msgID, ""}
+		u.saveLastViewedAt(ch.ID())
 
 		if u.v.GetBool(u.br.Protocol()+".prefixcontext") || u.v.GetBool(u.br.Protocol()+".suffixcontext") {
 			u.prefixContext(ch.ID(), msgID, "", "")
@@ -426,6 +426,7 @@ func CmdPrivMsg(s Server, u *User, msg *irc.Message) error {
 			u.msgLastMutex.Lock()
 			defer u.msgLastMutex.Unlock()
 			u.msgLast[toUser.User] = [2]string{msgID, ""}
+			u.saveLastViewedAt(toUser.User)
 
 			if u.v.GetBool(u.br.Protocol()+".prefixcontext") || u.v.GetBool(u.br.Protocol()+".suffixcontext") {
 				u.prefixContext(toUser.User, msgID, "", "")
@@ -512,6 +513,8 @@ func parseModifyMsg(u *User, msg *irc.Message, channelID string) bool {
 			return false
 		}
 		u.MsgSpoofUser(u, u.br.Protocol(), "msg: "+text+" could not be modified: "+err.Error())
+	} else {
+		u.saveLastViewedAt(channelID)
 	}
 
 	return true
@@ -592,8 +595,8 @@ func threadMsgChannel(u *User, msg *irc.Message, channelID string) bool {
 
 	u.msgLastMutex.Lock()
 	defer u.msgLastMutex.Unlock()
-
 	u.msgLast[channelID] = [2]string{msgID, threadID}
+	u.saveLastViewedAt(channelID)
 
 	if u.v.GetBool(u.br.Protocol()+".prefixcontext") || u.v.GetBool(u.br.Protocol()+".suffixcontext") {
 		u.prefixContext(channelID, msgID, "", "")
@@ -616,8 +619,8 @@ func threadMsgUser(u *User, msg *irc.Message, toUser string) bool {
 
 	u.msgLastMutex.Lock()
 	defer u.msgLastMutex.Unlock()
-
 	u.msgLast[toUser] = [2]string{msgID, threadID}
+	u.saveLastViewedAt(toUser)
 
 	if u.v.GetBool(u.br.Protocol()+".prefixcontext") || u.v.GetBool(u.br.Protocol()+".suffixcontext") {
 		u.prefixContext(toUser, msgID, "", "")

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -1010,11 +1010,11 @@ func saveLastViewedState(statePath string, lastViewedAt map[string]int64) error 
 	lastViewedAt["__LastViewedStateChecksum__"] = lastViewedAt["__LastViewedStateCreateTime__"] ^ currentTime
 
 	logger.Debug("Saving lastViewedAt")
-	
+
 	if err := gob.NewEncoder(f).Encode(lastViewedAt); err != nil {
-		return fmt.Errorf("gob encoding failed: %s",err)
+		return fmt.Errorf("gob encoding failed: %s", err)
 	}
-	
+
 	return nil
 }
 
@@ -1053,9 +1053,9 @@ func loadLastViewedState(statePath string, staleDuration string) (map[string]int
 	val, err := time.ParseDuration(staleDuration)
 	if err != nil {
 		stale = val.Milliseconds()
-		return fmt.Errorf("incorrect lastviewedstaleduration: %s",err)
+		return nil, fmt.Errorf("incorrect lastviewedstaleduration: %s", err)
 	}
-	
+
 	stale = val.Milliseconds()
 	lastSaved, ok := lastViewedAt["__LastViewedStateSavedTime__"]
 	if !ok || (lastSaved > 0 && lastSaved < currentTime-stale) {

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -172,19 +172,8 @@ func (u *User) handleDirectMessageEvent(event *bridge.DirectMessageEvent) {
 	defer u.lastViewedAtMutex.Unlock()
 	u.lastViewedAt[event.ChannelID] = model.GetMillis()
 	statePath := u.v.GetString(u.br.Protocol() + ".lastviewedsavefile")
-	if statePath == "" {
-		return
-	}
-	// We only want to save or dump out saved lastViewedAt on new
-	// messages after X time (default 5mins).
-	saveInterval := int64(300000)
-	val, err := time.ParseDuration(u.v.GetString(u.br.Protocol() + ".lastviewedsaveinterval"))
-	if err == nil {
-		saveInterval = val.Milliseconds()
-	}
-	if u.lastViewedAtSaved < (model.GetMillis() - saveInterval) {
-		saveLastViewedState(statePath, u.lastViewedAt)
-		u.lastViewedAtSaved = model.GetMillis()
+	if statePath != "" {
+		u.saveLastViewed(statePath)
 	}
 }
 
@@ -213,19 +202,8 @@ func (u *User) handleChannelAddEvent(event *bridge.ChannelAddEvent) {
 	defer u.lastViewedAtMutex.Unlock()
 	u.lastViewedAt[event.ChannelID] = model.GetMillis()
 	statePath := u.v.GetString(u.br.Protocol() + ".lastviewedsavefile")
-	if statePath == "" {
-		return
-	}
-	// We only want to save or dump out saved lastViewedAt on new
-	// messages after X time (default 5mins).
-	saveInterval := int64(300000)
-	val, err := time.ParseDuration(u.v.GetString(u.br.Protocol() + ".lastviewedsaveinterval"))
-	if err == nil {
-		saveInterval = val.Milliseconds()
-	}
-	if u.lastViewedAtSaved < (model.GetMillis() - saveInterval) {
-		saveLastViewedState(statePath, u.lastViewedAt)
-		u.lastViewedAtSaved = model.GetMillis()
+	if statePath != "" {
+		u.saveLastViewed(statePath)
 	}
 }
 
@@ -250,19 +228,8 @@ func (u *User) handleChannelRemoveEvent(event *bridge.ChannelRemoveEvent) {
 	defer u.lastViewedAtMutex.Unlock()
 	u.lastViewedAt[event.ChannelID] = model.GetMillis()
 	statePath := u.v.GetString(u.br.Protocol() + ".lastviewedsavefile")
-	if statePath == "" {
-		return
-	}
-	// We only want to save or dump out saved lastViewedAt on new
-	// messages after X time (default 5mins).
-	saveInterval := int64(300000)
-	val, err := time.ParseDuration(u.v.GetString(u.br.Protocol() + ".lastviewedsaveinterval"))
-	if err == nil {
-		saveInterval = val.Milliseconds()
-	}
-	if u.lastViewedAtSaved < (model.GetMillis() - saveInterval) {
-		saveLastViewedState(statePath, u.lastViewedAt)
-		u.lastViewedAtSaved = model.GetMillis()
+	if statePath != "" {
+		u.saveLastViewed(statePath)
 	}
 }
 
@@ -354,19 +321,8 @@ func (u *User) handleChannelMessageEvent(event *bridge.ChannelMessageEvent) {
 	defer u.lastViewedAtMutex.Unlock()
 	u.lastViewedAt[event.ChannelID] = model.GetMillis()
 	statePath := u.v.GetString(u.br.Protocol() + ".lastviewedsavefile")
-	if statePath == "" {
-		return
-	}
-	// We only want to save or dump out saved lastViewedAt on new
-	// messages after X time (default 5mins).
-	saveInterval := int64(300000)
-	val, err := time.ParseDuration(u.v.GetString(u.br.Protocol() + ".lastviewedsaveinterval"))
-	if err == nil {
-		saveInterval = val.Milliseconds()
-	}
-	if u.lastViewedAtSaved < (model.GetMillis() - saveInterval) {
-		saveLastViewedState(statePath, u.lastViewedAt)
-		u.lastViewedAtSaved = model.GetMillis()
+	if statePath != "" {
+		u.saveLastViewed(statePath)
 	}
 }
 
@@ -719,19 +675,8 @@ func (u *User) addUserToChannelWorker(channels <-chan *bridge.ChannelInfo, throt
 	u.lastViewedAtMutex.Lock()
 	defer u.lastViewedAtMutex.Unlock()
 	statePath := u.v.GetString(u.br.Protocol() + ".lastviewedsavefile")
-	if statePath == "" {
-		return
-	}
-	// We only want to save or dump out saved lastViewedAt on new
-	// messages after X time (default 5mins).
-	saveInterval := int64(300000)
-	val, err := time.ParseDuration(u.v.GetString(u.br.Protocol() + ".lastviewedsaveinterval"))
-	if err == nil {
-		saveInterval = val.Milliseconds()
-	}
-	if u.lastViewedAtSaved < (model.GetMillis() - saveInterval) {
-		saveLastViewedState(statePath, u.lastViewedAt)
-		u.lastViewedAtSaved = model.GetMillis()
+	if statePath != "" {
+		u.saveLastViewed(statePath)
 	}
 }
 
@@ -984,6 +929,20 @@ func (u *User) updateLastViewed(channelID string) {
 		time.Sleep(time.Duration(r) * time.Millisecond)
 		u.br.UpdateLastViewed(channelID)
 	}()
+}
+
+func (u *User) saveLastViewed(statePath string) {
+	// We only want to save or dump out saved lastViewedAt on new
+	// messages after X time (default 5mins).
+	saveInterval := int64(300000)
+	val, err := time.ParseDuration(u.v.GetString(u.br.Protocol() + ".lastviewedsaveinterval"))
+	if err == nil {
+		saveInterval = val.Milliseconds()
+	}
+	if u.lastViewedAtSaved < (model.GetMillis() - saveInterval) {
+		saveLastViewedState(statePath, u.lastViewedAt)
+		u.lastViewedAtSaved = model.GetMillis()
+	}
 }
 
 const lastViewedStateFormat = int64(1)

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -23,20 +23,25 @@ import (
 )
 
 type UserBridge struct {
-	Srv                Server
-	Credentials        bridge.Credentials
-	br                 bridge.Bridger            //nolint:structcheck
-	inprogress         bool                      //nolint:structcheck
-	lastViewedAt       map[string]int64          //nolint:structcheck
-	lastViewedAtMutex  sync.RWMutex              //nolint:structcheck
-	lastViewedAtSaved  int64                     //nolint:structcheck
-	msgCounter         map[string]int            //nolint:structcheck
-	msgLast            map[string][2]string      //nolint:structcheck
-	msgLastMutex       sync.RWMutex              //nolint:structcheck
-	msgMap             map[string]map[string]int //nolint:structcheck
-	msgMapMutex        sync.RWMutex              //nolint:structcheck
-	updateCounter      map[string]time.Time      //nolint:structcheck
-	updateCounterMutex sync.Mutex                //nolint:structcheck
+	Srv         Server
+	Credentials bridge.Credentials
+	br          bridge.Bridger //nolint:structcheck
+	inprogress  bool           //nolint:structcheck
+
+	lastViewedAtMutex sync.RWMutex     //nolint:structcheck
+	lastViewedAt      map[string]int64 //nolint:structcheck
+
+	lastViewedAtSaved int64          //nolint:structcheck
+	msgCounter        map[string]int //nolint:structcheck
+
+	msgLastMutex sync.RWMutex         //nolint:structcheck
+	msgLast      map[string][2]string //nolint:structcheck
+
+	msgMapMutex sync.RWMutex              //nolint:structcheck
+	msgMap      map[string]map[string]int //nolint:structcheck
+
+	updateCounterMutex sync.Mutex           //nolint:structcheck
+	updateCounter      map[string]time.Time //nolint:structcheck
 }
 
 func NewUserBridge(c net.Conn, srv Server, cfg *viper.Viper) *User {

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -669,12 +669,14 @@ func (u *User) addUserToChannelWorker(channels <-chan *bridge.ChannelInfo, throt
 			}
 		}
 
-		if !u.v.GetBool(u.br.Protocol() + ".disableautoview") {
-			u.updateLastViewed(brchannel.ID)
+		if len(mmPostList.Order) > 0 {
+			if !u.v.GetBool(u.br.Protocol() + ".disableautoview") {
+				u.updateLastViewed(brchannel.ID)
+			}
+			u.lastViewedAtMutex.Lock()
+			u.lastViewedAt[brchannel.ID] = model.GetMillis()
+			u.lastViewedAtMutex.Unlock()
 		}
-		u.lastViewedAtMutex.Lock()
-		u.lastViewedAt[brchannel.ID] = model.GetMillis()
-		u.lastViewedAtMutex.Unlock()
 	}
 	u.lastViewedAtMutex.Lock()
 	defer u.lastViewedAtMutex.Unlock()

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -58,11 +58,11 @@ func NewUserBridge(c net.Conn, srv Server, cfg *viper.Viper) *User {
 	if statePath != "" {
 		staleDuration := u.v.GetString("mattermost.lastviewedstaleduration")
 		lastViewedAt, err := loadLastViewedState(statePath, staleDuration)
-		if err == nil {
+		if err != nil {
+			logger.Warning("Unable to load saved lastViewedAt, using empty values: ", err)
+		} else {
 			logger.Info("Loaded lastViewedAt from ", time.Unix(lastViewedAt["__LastViewedStateSavedTime__"]/1000, 0))
 			u.lastViewedAt = lastViewedAt
-		} else {
-			logger.Warning("Unable to load saved lastViewedAt, using empty values: ", err)
 		}
 		u.lastViewedAtSaved = model.GetMillis()
 	}

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -1002,16 +1002,16 @@ func loadLastViewedState(statePath string, staleDuration string) (map[string]int
 
 	currentTime := model.GetMillis()
 
-	// Check if stale, last saved for town-square older than defined
+	// Check if stale, time last saved older than defined
 	// (default 30 days).
 	stale := int64(86400 * 30 * 1000)
 	val, err := time.ParseDuration(staleDuration)
 	if err == nil {
 		stale = val.Milliseconds()
 	}
-	townSquare, ok := lastViewedAt["town-square"]
-	if !ok || townSquare < currentTime-stale {
-		logger.Warning("File stale? Saved lastViewedAt for ~town-square too old: ", lastViewedAt["town-square"], currentTime)
+	lastsaved, ok := lastViewedAt["__LastViewedStateSavedTime__"]
+	if !ok || (lastsaved > 0 && lastsaved < currentTime-stale) {
+		logger.Warning("File stale? Last saved too old: ", lastViewedAt["__LastViewedStateSavedTime__"], currentTime)
 		return nil, errors.New("stale lastViewedAt state file")
 	}
 

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -59,7 +59,7 @@ func NewUserBridge(c net.Conn, srv Server, cfg *viper.Viper) *User {
 		staleDuration := u.v.GetString("mattermost.lastviewedstaleduration")
 		lastViewedAt, err := loadLastViewedState(statePath, staleDuration)
 		if err == nil {
-			logger.Info("Loaded lastViewedAt from ", lastViewedAt["__LastViewedStateSavedTime__"])
+			logger.Info("Loaded lastViewedAt from ", time.Unix(lastViewedAt["__LastViewedStateSavedTime__"]/1000, 0))
 			u.lastViewedAt = lastViewedAt
 		} else {
 			logger.Warning("Unable to load saved lastViewedAt, using empty values: ", err)
@@ -1011,9 +1011,9 @@ func loadLastViewedState(statePath string, staleDuration string) (map[string]int
 	if err == nil {
 		stale = val.Milliseconds()
 	}
-	lastsaved, ok := lastViewedAt["__LastViewedStateSavedTime__"]
-	if !ok || (lastsaved > 0 && lastsaved < currentTime-stale) {
-		logger.Warning("File stale? Last saved too old: ", lastViewedAt["__LastViewedStateSavedTime__"], currentTime)
+	lastSaved, ok := lastViewedAt["__LastViewedStateSavedTime__"]
+	if !ok || (lastSaved > 0 && lastSaved < currentTime-stale) {
+		logger.Warning("File stale? Last saved too old: ", time.Unix(lastViewedAt["__LastViewedStateSavedTime__"]/1000, 0))
 		return nil, errors.New("stale lastViewedAt state file")
 	}
 

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -1009,13 +1009,13 @@ func saveLastViewedState(statePath string, lastViewedAt map[string]int64) error 
 	// Simple checksum
 	lastViewedAt["__LastViewedStateChecksum__"] = lastViewedAt["__LastViewedStateCreateTime__"] ^ currentTime
 
-	err = gob.NewEncoder(f).Encode(lastViewedAt)
-	if err != nil {
-		logger.Warning("Unable to save lastViewedAt: ", err)
-	} else {
-		logger.Debug("Saving lastViewedAt")
+	logger.Debug("Saving lastViewedAt")
+	
+	if err := gob.NewEncoder(f).Encode(lastViewedAt); err != nil {
+		return fmt.Errorf("gob encoding failed: %s",err)
 	}
-	return err
+	
+	return nil
 }
 
 func loadLastViewedState(statePath string, staleDuration string) (map[string]int64, error) {

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -1026,19 +1026,19 @@ func loadLastViewedState(statePath string, staleDuration string) (map[string]int
 	var lastViewedAt map[string]int64
 	err = gob.NewDecoder(f).Decode(&lastViewedAt)
 	if err != nil {
-		logger.Warning("Unable to load lastViewedAt: ", err)
+		logger.Debug("Unable to load lastViewedAt: ", err)
 		return nil, err
 	}
 
 	if lastViewedAt["__LastViewedStateFormat__"] != LastViewedStateFormat {
-		logger.Warning("State format version mismatch: ", lastViewedAt["__LastViewedStateFormat__"], " vs. ", LastViewedStateFormat)
+		logger.Debug("State format version mismatch: ", lastViewedAt["__LastViewedStateFormat__"], " vs. ", LastViewedStateFormat)
 		return nil, errors.New("version mismatch")
 	}
 	checksum := lastViewedAt["__LastViewedStateChecksum__"]
 	createtime := lastViewedAt["__LastViewedStateCreateTime__"]
 	savedtime := lastViewedAt["__LastViewedStateSavedTime__"]
 	if createtime^savedtime != checksum {
-		logger.Warning("Checksum mismatch: (saved checksum, state file creation, last saved time)", checksum, createtime, savedtime)
+		logger.Debug("Checksum mismatch: (saved checksum, state file creation, last saved time)", checksum, createtime, savedtime)
 		return nil, errors.New("checksum mismatch")
 	}
 
@@ -1053,7 +1053,7 @@ func loadLastViewedState(statePath string, staleDuration string) (map[string]int
 	}
 	lastSaved, ok := lastViewedAt["__LastViewedStateSavedTime__"]
 	if !ok || (lastSaved > 0 && lastSaved < currentTime-stale) {
-		logger.Warning("File stale? Last saved too old: ", time.Unix(lastViewedAt["__LastViewedStateSavedTime__"]/1000, 0))
+		logger.Debug("File stale? Last saved too old: ", time.Unix(lastViewedAt["__LastViewedStateSavedTime__"]/1000, 0))
 		return nil, errors.New("stale lastViewedAt state file")
 	}
 

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -384,6 +384,7 @@ func (u *User) handleReactionEvent(event interface{}) {
 		}
 
 		u.handleDirectMessageEvent(e)
+		u.saveLastViewedAt(channelID)
 
 		return
 	}
@@ -399,6 +400,7 @@ func (u *User) handleReactionEvent(event interface{}) {
 	}
 
 	u.handleChannelMessageEvent(e)
+	u.saveLastViewedAt(channelID)
 }
 
 func (u *User) CreateUserFromInfo(info *bridge.UserInfo) *User {

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -912,8 +912,7 @@ func (u *User) loadLastViewedAt() map[string]int64 {
 	return lastViewedAt
 }
 
-// Default 5 mins
-const defaultSaveInterval = int64(300 * 1000)
+const defaultSaveInterval = int64((5 * time.Minute) / time.Millisecond)
 
 func (u *User) saveLastViewedAt(channelID string) {
 	u.lastViewedAtMutex.Lock()
@@ -944,9 +943,6 @@ func (u *User) saveLastViewedAt(channelID string) {
 
 const lastViewedStateFormat = int64(1)
 
-// Default 30 days
-const defaultStaleDuration = int64(86400 * 30 * 1000)
-
 func saveLastViewedAtStateFile(statePath string, lastViewedAt map[string]int64) error {
 	f, err := os.Create(statePath)
 	if err != nil {
@@ -973,6 +969,8 @@ func saveLastViewedAtStateFile(statePath string, lastViewedAt map[string]int64) 
 
 	return nil
 }
+
+const defaultStaleDuration = int64((30 * 24 * time.Hour) / time.Millisecond)
 
 func loadLastViewedAtStateFile(statePath string, staleDuration string) (map[string]int64, error) {
 	f, err := os.Open(statePath)

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -898,10 +898,10 @@ func (u *User) loadLastViewedAt() map[string]int64 {
 	lastViewedAt, err := loadLastViewedAtStateFile(statePath, staleDuration)
 	if err != nil {
 		logger.Warning("Unable to load saved lastViewedAt, using empty values: ", err)
-	} else {
-		logger.Info("Loaded lastViewedAt from ", time.Unix(lastViewedAt["__LastViewedStateSavedTime__"]/1000, 0))
-		u.lastViewedAt = lastViewedAt
+		return make(map[string]int64)
 	}
+
+	logger.Info("Loaded lastViewedAt from ", time.Unix(lastViewedAt["__LastViewedStateSavedTime__"]/1000, 0))
 	u.lastViewedAtSaved = model.GetMillis()
 
 	return lastViewedAt

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -994,7 +994,7 @@ const defaultStaleDuration = int64(86400 * 30 * 1000)
 func saveLastViewedState(statePath string, lastViewedAt map[string]int64) error {
 	f, err := os.Create(statePath)
 	if err != nil {
-		logger.Warning("Unable to save lastViewedAt: ", err)
+		logger.Debug("Unable to save lastViewedAt: ", err)
 		return err
 	}
 	defer f.Close()
@@ -1048,15 +1048,14 @@ func loadLastViewedState(statePath string, staleDuration string) (map[string]int
 	currentTime := model.GetMillis()
 
 	// Check if stale, time last saved older than defined
-	// (default 30 days).
-	stale := defaultStaleDuration
+	var stale int64
 	val, err := time.ParseDuration(staleDuration)
 	if err != nil {
+		stale = defaultStaleDuration
+	} else {
 		stale = val.Milliseconds()
-		return nil, fmt.Errorf("incorrect lastviewedstaleduration: %s", err)
 	}
 
-	stale = val.Milliseconds()
 	lastSaved, ok := lastViewedAt["__LastViewedStateSavedTime__"]
 	if !ok || (lastSaved > 0 && lastSaved < currentTime-stale) {
 		logger.Debug("File stale? Last saved too old: ", time.Unix(lastViewedAt["__LastViewedStateSavedTime__"]/1000, 0))

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -1051,9 +1051,12 @@ func loadLastViewedState(statePath string, staleDuration string) (map[string]int
 	// (default 30 days).
 	stale := defaultStaleDuration
 	val, err := time.ParseDuration(staleDuration)
-	if err == nil {
+	if err != nil {
 		stale = val.Milliseconds()
+		return fmt.Errorf("incorrect lastviewedstaleduration: %s",err)
 	}
+	
+	stale = val.Milliseconds()
 	lastSaved, ok := lastViewedAt["__LastViewedStateSavedTime__"]
 	if !ok || (lastSaved > 0 && lastSaved < currentTime-stale) {
 		logger.Debug("File stale? Last saved too old: ", time.Unix(lastViewedAt["__LastViewedStateSavedTime__"]/1000, 0))


### PR DESCRIPTION
This ensures we only replay backlog for what we haven't seen.

It is not enabled by default and only enabled when something like this is added to mattermost.toml:

    LastViewedSavePath = "matterircd-lastsaved.db"