### PR TITLE
Allow forcing anti-idle

### DIFF
--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -69,7 +69,7 @@ func (m *Mattermost) loginToMattermost(onWsConnect func()) (*matterclient.Client
 	}
 
 	// do anti idle on town-square, every installation should have this channel
-	mc.AntiIdle = !m.v.GetBool("mattermost.DisableAutoView")
+	mc.AntiIdle = !m.v.GetBool("mattermost.DisableAutoView") || m.v.GetBool("mattermost.ForceAntiIdle")
 	mc.OnWsConnect = onWsConnect
 
 	if m.v.GetBool("debug") {

--- a/matterircd.toml.example
+++ b/matterircd.toml.example
@@ -98,8 +98,10 @@ PrefixMainTeam = false
 #Only mark a conversation as viewed when you reply to that conversation or
 #channel. This prevents Mattermost from clearing mobile app notifications
 #instantly. Note that this prevents you from always appearing as online
-#(anti-idle support is turned off) (default false)
+#(anti-idle support is turned off unless ForceAntiIdle) (default false)
 DisableAutoView = false
+# Force and enable anti-idle. Useful for when DisableAutoView.
+# ForceAntiIdle = true
 
 # If users set a Nickname, matterircd could either choose that or the Username
 # to display in the IRC client. The option PreferNickname controls that, the


### PR DESCRIPTION
Useful for when you don't want channels to be marked as seen so you can view them on another device but at the same time, you want to be seen as not idling.