### PR TITLE
Skip already seen messages when replaying

### DIFF
--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -560,7 +560,7 @@ func (u *User) addUserToChannelWorker(channels <-chan *bridge.ChannelInfo, throt
 		// We used to stored last viewed at if present.
 		u.lastViewedAtMutex.RLock()
 		if lastViewedAt, ok := u.lastViewedAt[brchannel.ID]; ok {
-			since = lastViewedAt
+			since = lastViewedAt + 1
 		}
 		u.lastViewedAtMutex.RUnlock()
 		// post everything to the channel you haven't seen yet
@@ -604,9 +604,9 @@ func (u *User) addUserToChannelWorker(channels <-chan *bridge.ChannelInfo, throt
 				if showReplayHdr {
 					date := ts.Format("2006-01-02 15:04:05")
 					if brchannel.DM {
-						spoof(nick, fmt.Sprintf("Replaying since %s", date))
+						spoof(nick, fmt.Sprintf("\x02Replaying since %s\x0f", date))
 					} else {
-						spoof("matterircd", fmt.Sprintf("Replaying since %s", date))
+						spoof("matterircd", fmt.Sprintf("\x02Replaying since %s\x0f", date))
 					}
 					showReplayHdr = false
 				}

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -590,6 +590,15 @@ func (u *User) addUserToChannelWorker(channels <-chan *bridge.ChannelInfo, throt
 				continue
 			}
 
+			// GetPostsSince will return older messages with reaction
+			// changes since LastViewedAt. This will be confusing as
+			// the user will think it's a duplicate, or a post out of
+			// order. Plus, we don't show reaction changes when
+			// relaying messages/logs so let's skip these.
+			if p.CreateAt < since {
+				continue
+			}
+
 			ts := time.Unix(0, p.CreateAt*int64(time.Millisecond))
 
 			props := p.GetProps()


### PR DESCRIPTION
GetPostsSince will return older messages with reaction changes since LastViewedAt (query looks to be using the posts' update_at. This may be confusing as the user may think it's a duplicate, or a post out of order. Plus, we currently don't show reaction changes when relaying messages/logs so let's skip these. e.g.

    $ curl -i -H 'Authorization: Bearer some-token' 'https://mychat.internal/api/v4/channels/channel_id/posts?since=1611354473840'; echo
    HTTP/2 200
    server: openresty/1.15.8.2
    date: Sat, 23 Jan 2021 21:21:37 GMT
    content-type: application/json
    content-length: 1252
    vary: Accept-Encoding
    strict-transport-security: max-age=15724800; includeSubDomains
    expires: 0
    vary: Accept-Encoding
    x-request-id: hm9ny96yh3...dga
    x-version-id: 5.29.0.5.29.0.88ed32c9aea1c37a5f3b7d9af1b55e24.true
    
    {"order":["n5wcpsj8p3...7fh"],"posts":{"n5wcpsj8p3...7fh":{"id":"n5wcpsj8p3...7fh","create_at":1611354253439,"update_at":1611357403391,"edit_at":0,"delete_at":0,"is_pinned":false,"user_id":"6omasxec5j...jgy","channel_id":"mpyu47h5zj...mey","root_id":"yq1or8hb4i...8hh","parent_id":"yq1or8hb4i...8hh","original_id":"","message":"<redacted>","type":"","props":{},"hashtags":"","pending_post_id":"","has_reactions":true,"reply_count":0,"metadata":{"reactions":[{"user_id":"cx1zy66pxt...pbh","post_id":"n5wcpsj8p3...7fh","emoji_name":"+1","create_at":1611357403385}]}},},"next_post_id":"","prev_post_id":""}