### PR TITLE
Add logging when replaying logs

### DIFF
--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -613,11 +613,14 @@ func (u *User) addUserToChannelWorker(channels <-chan *bridge.ChannelInfo, throt
 				}
 				if showReplayHdr {
 					date := ts.Format("2006-01-02 15:04:05")
+					channame := brchannel.Name
 					if brchannel.DM {
 						spoof(nick, fmt.Sprintf("\x02Replaying since %s\x0f", date))
 					} else {
 						spoof("matterircd", fmt.Sprintf("\x02Replaying since %s\x0f", date))
+						channame = fmt.Sprintf("#%s", brchannel.Name)
 					}
+					logger.Infof("Replaying logs for %s (%s) since %s", brchannel.ID, channame, date)
 					showReplayHdr = false
 				}
 


### PR DESCRIPTION
Useful for those using IRC bouncers such as bip and znc to debug issues with replaying. E.g. if matterircd is replaying the same messages over and over or if it's the bouncer doing so.