### PR TITLE
Sanitize nick before sending PRIVMSG irc command

### DIFF
--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -239,7 +239,7 @@ func (u *User) handleChannelMessageEvent(event *bridge.ChannelMessageEvent) {
 		        CHANNEL_DIRECT                 = "D"
 				CHANNEL_GROUP                  = "G"
 	*/
-	nick := event.Sender.Nick
+	nick := sanitizeNick(event.Sender.Nick)
 	logger.Debug("in handleChannelMessageEvent")
 	ch := u.getMessageChannel(event.ChannelID, event.ChannelType, event.Sender)
 	if event.Sender.Me {


### PR DESCRIPTION
The nick sanitizing code missed a spot; if a nick with spaces in it sends a message on Slack, the PRIVMSG sent over IRC is malformed.
