### PR TITLE
Fix golangci-lint dupl, unused, nestif, and gocritic

### DIFF
--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -165,27 +165,6 @@ func (m *Mattermost) checkWsActionMessage(rmsg *model.WebSocketEvent, throttle *
 	}
 }
 
-// antiIdle does a lastviewed every 60 seconds so that the user is shown as online instead of away
-func (m *Mattermost) antiIdle(channelID string, quitChan chan struct{}) {
-	ticker := time.NewTicker(time.Second * 60)
-
-	for {
-		select {
-		case <-quitChan:
-			logger.Debugf("stopping antiIdle loop for %s", channelID)
-			return
-		case <-ticker.C:
-			if m.mc == nil {
-				logger.Error("antiidle: don't have a connection, exiting loop.")
-				return
-			}
-
-			logger.Tracef("antiIdle %s", channelID)
-			m.mc.UpdateLastViewed(channelID)
-		}
-	}
-}
-
 func (m *Mattermost) Invite(channelID, username string) error {
 	_, resp := m.mc.Client.AddChannelMember(channelID, username)
 	if resp.Error != nil {
@@ -720,7 +699,6 @@ func (m *Mattermost) handleWsActionPost(rmsg *model.WebSocketEvent) {
 		return
 	}
 
-	// nolint:nestif
 	if data.ParentId != "" {
 		parentPost, resp := m.mc.Client.GetPost(data.ParentId, "")
 		if resp.Error != nil {

--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -630,22 +630,6 @@ func (s *Slack) handleMemberJoinedChannel(rmsg *slack.MemberJoinedChannelEvent) 
 	s.eventChan <- event
 }
 
-func (s *Slack) getBotname(rmsg *slack.MessageEvent) string {
-	botname := ""
-
-	if rmsg.User == "" && rmsg.BotID != "" {
-		botname = rmsg.Username
-		if botname == "" {
-			bot, _ := s.rtm.GetBotInfo(rmsg.BotID)
-			if bot.Name != "" {
-				botname = bot.Name
-			}
-		}
-	}
-
-	return botname
-}
-
 func (s *Slack) getSlackUserFromMessage(rmsg *slack.MessageEvent) (*slack.User, error) {
 	usr := rmsg.User
 	if rmsg.SubType == "message_changed" {

--- a/mm-go-irckit/commands.go
+++ b/mm-go-irckit/commands.go
@@ -6,7 +6,7 @@ import (
 	"github.com/sorcix/irc"
 )
 
-// The error returned when an invalid command is issued.
+// ErrUnknownCommand The error returned when an invalid command is issued.
 var ErrUnknownCommand = errors.New("unknown command")
 
 // Handler is a container for an irc.Message handler.

--- a/mm-go-irckit/server.go
+++ b/mm-go-irckit/server.go
@@ -134,7 +134,6 @@ type server struct {
 
 	u *User
 	sync.RWMutex
-	count    int
 	users    map[string]*User
 	channels map[string]Channel
 }

--- a/mm-go-irckit/server_commands.go
+++ b/mm-go-irckit/server_commands.go
@@ -606,27 +606,7 @@ func threadMsgChannel(u *User, msg *irc.Message, channelID string) bool {
 }
 
 func threadMsgUser(u *User, msg *irc.Message, toUser string) bool {
-	threadID, text := parseThreadID(u, msg, toUser)
-	if threadID == "" {
-		return false
-	}
-
-	msgID, err := u.br.MsgUserThread(toUser, threadID, text)
-	if err != nil {
-		u.MsgSpoofUser(u, u.br.Protocol(), "msg: "+text+" could not be send: "+err.Error())
-		return false
-	}
-
-	u.msgLastMutex.Lock()
-	defer u.msgLastMutex.Unlock()
-	u.msgLast[toUser] = [2]string{msgID, threadID}
-	u.saveLastViewedAt(toUser)
-
-	if u.v.GetBool(u.br.Protocol()+".prefixcontext") || u.v.GetBool(u.br.Protocol()+".suffixcontext") {
-		u.prefixContext(toUser, msgID, "", "")
-	}
-
-	return true
+	return threadMsgChannel(u, msg, toUser)
 }
 
 // CmdQuit is a handler for the /QUIT command.

--- a/mm-go-irckit/server_commands.go
+++ b/mm-go-irckit/server_commands.go
@@ -176,7 +176,7 @@ func CmdList(s Server, u *User, msg *irc.Message) error {
 	r = append(r, &irc.Message{
 		Prefix:   s.Prefix(),
 		Params:   []string{u.Nick},
-		Command:  irc.RPL_LISTEND,
+		Command:  irc.RPL_LISTEND, // nolint:misspell
 		Trailing: "End of /LIST",
 	})
 	return u.Encode(r...)

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -206,7 +206,7 @@ func (u *User) handleChannelRemoveEvent(event *bridge.ChannelRemoveEvent) {
 	u.saveLastViewedAt(event.ChannelID)
 }
 
-func (u *User) getMessageChannel(channelID, channelType string, sender *bridge.UserInfo) Channel {
+func (u *User) getMessageChannel(channelID string, sender *bridge.UserInfo) Channel {
 	ch := u.Srv.Channel(channelID)
 	ghost := u.createUserFromInfo(sender)
 
@@ -241,7 +241,7 @@ func (u *User) handleChannelMessageEvent(event *bridge.ChannelMessageEvent) {
 	*/
 	nick := event.Sender.Nick
 	logger.Debug("in handleChannelMessageEvent")
-	ch := u.getMessageChannel(event.ChannelID, event.ChannelType, event.Sender)
+	ch := u.getMessageChannel(event.ChannelID, event.Sender)
 	if event.Sender.Me {
 		nick = u.Nick
 	}
@@ -294,7 +294,7 @@ func (u *User) handleChannelMessageEvent(event *bridge.ChannelMessageEvent) {
 }
 
 func (u *User) handleFileEvent(event *bridge.FileEvent) {
-	ch := u.getMessageChannel(event.ChannelID, event.ChannelType, event.Sender)
+	ch := u.getMessageChannel(event.ChannelID, event.Sender)
 
 	switch event.ChannelType {
 	case "D":
@@ -795,7 +795,7 @@ func (u *User) loginTo(protocol string) error {
 	return nil
 }
 
-// nolint:unparam,unused
+// nolint:unparam
 func (u *User) logoutFrom(protocol string) error {
 	logger.Debug("logging out from", protocol)
 

--- a/pkg/matterclient/matterclient.go
+++ b/pkg/matterclient/matterclient.go
@@ -362,14 +362,15 @@ func (m *Client) doLogin(firstConnection bool, b *backoff.Backoff) error {
 	for {
 		m.logger.Debugf("%s %s %s %s", logmsg, m.Credentials.Team, m.Credentials.Login, m.Credentials.Server)
 
-		if m.Credentials.Token != "" {
+		switch {
+		case m.Credentials.Token != "":
 			user, resp, err = m.doLoginToken()
 			if err != nil {
 				return err
 			}
-		} else if m.Credentials.MFAToken != "" {
+		case m.Credentials.MFAToken != "":
 			user, resp = m.Client.LoginWithMFA(m.Credentials.Login, m.Credentials.Pass, m.Credentials.MFAToken)
-		} else {
+		default:
 			user, resp = m.Client.Login(m.Credentials.Login, m.Credentials.Pass)
 		}
 


### PR DESCRIPTION
That's the following:

    $ golangci-lint run
    WARN [runner] Can't process result by diff processor: can't prepare diff by revgrep: no version control repository found
    mm-go-irckit/server_commands.go:584: 584-606 lines are duplicate of `mm-go-irckit/server_commands.go:608-630` (dupl)
    func threadMsgChannel(u *User, msg *irc.Message, channelID string) bool {
            threadID, text := parseThreadID(u, msg, channelID)
            if threadID == "" {
                    return false
            }

            msgID, err := u.br.MsgChannelThread(channelID, threadID, text)
            if err != nil {
                    u.MsgSpoofUser(u, u.br.Protocol(), "msg: "+text+" could not be send: "+err.Error())
                    return false
            }

            u.msgLastMutex.Lock()
            defer u.msgLastMutex.Unlock()
            u.msgLast[channelID] = [2]string{msgID, threadID}
            u.saveLastViewedAt(channelID)

            if u.v.GetBool(u.br.Protocol()+".prefixcontext") || u.v.GetBool(u.br.Protocol()+".suffixcontext") {
                    u.prefixContext(channelID, msgID, "", "")
            }

            return true
    }
    mm-go-irckit/server_commands.go:608: 608-630 lines are duplicate of `mm-go-irckit/server_commands.go:584-606` (dupl)
    func threadMsgUser(u *User, msg *irc.Message, toUser string) bool {
            threadID, text := parseThreadID(u, msg, toUser)
            if threadID == "" {
                    return false
            }

            msgID, err := u.br.MsgUserThread(toUser, threadID, text)
            if err != nil {
                    u.MsgSpoofUser(u, u.br.Protocol(), "msg: "+text+" could not be send: "+err.Error())
                    return false
            }

            u.msgLastMutex.Lock()
            defer u.msgLastMutex.Unlock()
            u.msgLast[toUser] = [2]string{msgID, threadID}
            u.saveLastViewedAt(toUser)

            if u.v.GetBool(u.br.Protocol()+".prefixcontext") || u.v.GetBool(u.br.Protocol()+".suffixcontext") {
                    u.prefixContext(toUser, msgID, "", "")
            }

            return true
    }
    pkg/matterclient/matterclient.go:365:3: ifElseChain: rewrite if-else to switch statement (gocritic)
                    if m.Credentials.Token != "" {
                    ^
    mm-go-irckit/commands.go:9:1: comment on exported var `ErrUnknownCommand` should be of the form `ErrUnknownCommand ...` (golint)
    // The error returned when an invalid command is issued.
    ^
    mm-go-irckit/server_commands.go:179:21: `LISTEND` is a misspelling of `LISTENED` (misspell)
                    Command:  irc.RPL_LISTEND,
                                      ^
    mm-go-irckit/userbridge.go:265:2: `if u.v.GetBool(u.br.Protocol() + ".prefixcontext")` is deeply nested (complexity: 5) (nestif)
            if u.v.GetBool(u.br.Protocol() + ".prefixcontext") {
            ^
    mm-go-irckit/server.go:137:2: `count` is unused (structcheck)
            count    int
            ^
    mm-go-irckit/userbridge.go:209:45: `(*User).getMessageChannel` - `channelType` is unused (unparam)
    func (u *User) getMessageChannel(channelID, channelType string, sender *bridge.UserInfo) Channel {
                                                ^
    bridge/mattermost/mattermost.go:169:22: func `(*Mattermost).antiIdle` is unused (unused)
    bridge/slack/slack.go:633:17: func `(*Slack).getBotname` is unused (unused)
    bridge/mattermost/mattermost.go:723:2: directive `// nolint:nestif` is unused for linter nestif (nolintlint)
            // nolint:nestif
            ^
    mm-go-irckit/userbridge.go:801:1: directive `// nolint:unparam,unused` is unused for linter unused (nolintlint)
    // nolint:unparam,unused
    ^

Ignoring the funlen, goconst, gocognit, gocyclo, and a bunch of other nestif ones for now.