### PR TITLE
Allow adding or removing reactions

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -23,6 +23,9 @@ type Bridger interface {
 	MsgChannel(channelID, text string) (string, error)
 	MsgChannelThread(channelID, parentID, text string) (string, error)
 
+	SaveReaction(msgID, emoji string) error
+	DeleteReaction(msgID, emoji string) error
+
 	StatusUser(userID string) (string, error)
 	StatusUsers() (map[string]string, error)
 	SetStatus(status string) error

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -23,8 +23,8 @@ type Bridger interface {
 	MsgChannel(channelID, text string) (string, error)
 	MsgChannelThread(channelID, parentID, text string) (string, error)
 
-	SaveReaction(msgID, emoji string) error
-	DeleteReaction(msgID, emoji string) error
+	AddReaction(msgID, emoji string) error
+	RemoveReaction(msgID, emoji string) error
 
 	StatusUser(userID string) (string, error)
 	StatusUsers() (map[string]string, error)

--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -341,6 +341,42 @@ func (m *Mattermost) ModifyPost(msgID, text string) error {
 	return nil
 }
 
+func (m *Mattermost) SaveReaction(msgID, emoji string) error {
+	logger.Debugf("adding reaction %#v, %#v", msgID, emoji)
+	reaction := &model.Reaction{
+		UserId:    m.mc.User.Id,
+		PostId:    msgID,
+		EmojiName: emoji,
+		CreateAt:  0,
+	}
+
+	_, resp := m.mc.Client.SaveReaction(reaction)
+
+	if resp.Error != nil {
+		return resp.Error
+	}
+
+	return nil
+}
+
+func (m *Mattermost) DeleteReaction(msgID, emoji string) error {
+	logger.Debugf("removing reaction %#v, %#v", msgID, emoji)
+	reaction := &model.Reaction{
+		UserId:    m.mc.User.Id,
+		PostId:    msgID,
+		EmojiName: emoji,
+		CreateAt:  0,
+	}
+
+	_, resp := m.mc.Client.DeleteReaction(reaction)
+
+	if resp.Error != nil {
+		return resp.Error
+	}
+
+	return nil
+}
+
 func (m *Mattermost) Topic(channelID string) string {
 	return m.mc.GetChannelHeader(channelID)
 }

--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -341,7 +341,7 @@ func (m *Mattermost) ModifyPost(msgID, text string) error {
 	return nil
 }
 
-func (m *Mattermost) SaveReaction(msgID, emoji string) error {
+func (m *Mattermost) AddReaction(msgID, emoji string) error {
 	logger.Debugf("adding reaction %#v, %#v", msgID, emoji)
 	reaction := &model.Reaction{
 		UserId:    m.mc.User.Id,
@@ -359,7 +359,7 @@ func (m *Mattermost) SaveReaction(msgID, emoji string) error {
 	return nil
 }
 
-func (m *Mattermost) DeleteReaction(msgID, emoji string) error {
+func (m *Mattermost) RemoveReaction(msgID, emoji string) error {
 	logger.Debugf("removing reaction %#v, %#v", msgID, emoji)
 	reaction := &model.Reaction{
 		UserId:    m.mc.User.Id,

--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -933,10 +933,10 @@ func (s *Slack) ModifyPost(channelID, text string) error {
 	return nil
 }
 
-func (s *Slack) SaveReaction(msgID, emoji string) error {
+func (s *Slack) AddReaction(msgID, emoji string) error {
 	return nil
 }
 
-func (s *Slack) DeleteReaction(msgID, emoji string) error {
+func (s *Slack) RemoveReaction(msgID, emoji string) error {
 	return nil
 }

--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -932,3 +932,11 @@ func (s *Slack) MsgChannelThread(username, parentID, text string) (string, error
 func (s *Slack) ModifyPost(channelID, text string) error {
 	return nil
 }
+
+func (s *Slack) SaveReaction(msgID, emoji string) error {
+	return nil
+}
+
+func (s *Slack) DeleteReaction(msgID, emoji string) error {
+	return nil
+}


### PR DESCRIPTION
This is to specific posts/messages, using the same syntax as you would via the Mattermost UI (+:emoji_name: and -:emoji_name:).

    |20:22 <hloeung> @@e9jdm8qwxtdq88nb949i6tcp6y +:coffee:
    |20:22 <hloeung> added reaction: coffee [↪@@e9jdm8qwxtdq88nb949i6tcp6y]
    |20:22 <hloeung> @@e9jdm8qwxtdq88nb949i6tcp6y -:coffee:
    |20:22 <hloeung> removed reaction: coffee [↪@@e9jdm8qwxtdq88nb949i6tcp6y]

One for you @devec0 but too late ;)