### PR TITLE
Flush buffers on reactions, allows adding various reactions in sequence, also replies to threads or message modifications

### DIFF
--- a/mm-go-irckit/user.go
+++ b/mm-go-irckit/user.go
@@ -3,6 +3,7 @@ package irckit
 import (
 	"fmt"
 	"net"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -180,9 +181,10 @@ func (u *User) Decode() {
 					// start timer now
 					t.Reset(time.Duration(bufferTimeout) * time.Millisecond)
 				} else {
-					if strings.HasPrefix(msg.Trailing, "\x01ACTION") {
+					re := regexp.MustCompile(`^(?:\@\@|s/)(?:[0-9a-f]{3}|[0-9a-z]{26}|!!)|/`)
+					if strings.HasPrefix(msg.Trailing, "\x01ACTION") || re.MatchString(msg.Trailing) {
 						// flush buffer
-						logger.Debug("flushing buffer because of /me")
+						logger.Debug("flushing buffer because of /me, replies to threads, and message modifications")
 						u.BufferedMsg.Trailing = strings.TrimSpace(u.BufferedMsg.Trailing)
 						u.DecodeCh <- u.BufferedMsg
 						u.BufferedMsg = nil


### PR DESCRIPTION
Split out from https://github.com/42wim/matterircd/pull/386

So you can add multiple reactions in sequence, especially with a high PasteBufferTimeout. This also allows replying to threads or modifying messages in sequence without the chance it'll be sent as-is. e.g.

    Test
    s//
    Two

Will delete the message `Test` and send `Two` rather than send all 3 lines with `s//` sent as text.