### PR TITLE
Fix permissions issues when replying to threads in DM

### DIFF
--- a/mm-go-irckit/server_commands.go
+++ b/mm-go-irckit/server_commands.go
@@ -581,13 +581,19 @@ func parseThreadID(u *User, msg *irc.Message, channelID string) (string, string)
 	return "", ""
 }
 
-func threadMsgChannel(u *User, msg *irc.Message, channelID string) bool {
+func threadMsgChannelUser(u *User, msg *irc.Message, channelID string, toUser bool) bool {
 	threadID, text := parseThreadID(u, msg, channelID)
 	if threadID == "" {
 		return false
 	}
 
-	msgID, err := u.br.MsgChannelThread(channelID, threadID, text)
+	var msgID string
+	var err error
+	if toUser {
+		msgID, err = u.br.MsgUserThread(channelID, threadID, text)
+	} else {
+		msgID, err = u.br.MsgChannelThread(channelID, threadID, text)
+	}
 	if err != nil {
 		u.MsgSpoofUser(u, u.br.Protocol(), "msg: "+text+" could not be send: "+err.Error())
 		return false
@@ -605,8 +611,12 @@ func threadMsgChannel(u *User, msg *irc.Message, channelID string) bool {
 	return true
 }
 
+func threadMsgChannel(u *User, msg *irc.Message, channelID string) bool {
+	return threadMsgChannelUser(u, msg, channelID, false)
+}
+
 func threadMsgUser(u *User, msg *irc.Message, toUser string) bool {
-	return threadMsgChannel(u, msg, toUser)
+	return threadMsgChannelUser(u, msg, toUser, true)
 }
 
 // CmdQuit is a handler for the /QUIT command.


### PR DESCRIPTION
This was introduced in commit c68410c5 where threadMsgUser() now calls
threadMsgChannel() which then incorrectly calls u.br.MsgChannelThread().

    msg: Test could not be send: You do not have the appropriate permissions.,

Apologies for introducing this bug.