### PR TITLE
Show scrollback in same channel/query window

### DIFF
--- a/mm-go-irckit/service.go
+++ b/mm-go-irckit/service.go
@@ -322,11 +322,23 @@ func scrollback(u *User, toUser *User, args []string, service string) {
 			if post == "" {
 				continue
 			}
-			if strings.HasPrefix(args[0], "#") {
-				spoof(nick, "["+ts.Format("2006-01-02 15:04")+"] "+post)
-				continue
+
+			switch {
+			case u.v.GetString(u.br.Protocol()+".threadcontext") == "mattermost" && strings.HasPrefix(args[0], "#"):
+				threadMsgID := u.prefixContext("", p.Id, p.ParentId, "")
+				scrollbackMsg := u.formatContextMessage(ts.Format("2006-01-02 15:04"), threadMsgID, post)
+				spoof(nick, scrollbackMsg)
+			case u.v.GetString(u.br.Protocol()+".threadcontext") == "mattermost":
+				threadMsgID := u.prefixContext("", p.Id, p.ParentId, "")
+				scrollbackMsg := u.formatContextMessage(ts.Format("2006-01-02 15:04"), threadMsgID, post)
+				u.MsgSpoofUser(scrollbackUser, nick, scrollbackMsg)
+			case strings.HasPrefix(args[0], "#"):
+				scrollbackMsg := "[" + ts.Format("2006-01-02 15:04") + "] " + post
+				spoof(nick, scrollbackMsg)
+			default:
+				scrollbackMsg := "[" + ts.Format("2006-01-02 15:04") + "]" + " <" + nick + "> " + post
+				u.MsgSpoofUser(scrollbackUser, nick, scrollbackMsg)
 			}
-			u.MsgSpoofUser(scrollbackUser, nick, "["+ts.Format("2006-01-02 15:04")+"]"+" <"+nick+"> "+post)
 		}
 
 		if len(p.FileIds) > 0 {

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -607,13 +607,13 @@ func (u *User) addUserToChannelWorker(channels <-chan *bridge.ChannelInfo, throt
 
 			props := p.GetProps()
 			botname, override := props["override_username"].(string)
+			user := u.br.GetUser(p.UserId)
+			nick := user.Nick
+			if override {
+				nick = botname
+			}
 
 			for _, post := range strings.Split(p.Message, "\n") {
-				user := u.br.GetUser(p.UserId)
-				nick := user.Nick
-				if override {
-					nick = botname
-				}
 				if showReplayHdr {
 					date := ts.Format("2006-01-02 15:04:05")
 					channame := brchannel.Name


### PR DESCRIPTION
Rather than show as being from the "mattermost" user or in the "mattermost" query window, this shows scrollback text in the same window as the one we're requesting scrollback for. Fixes https://github.com/42wim/matterircd/issues/391