### PR TITLE
Set correct IRC PRIVMSG nick when receiving direct messages

### DIFF
--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -157,7 +157,7 @@ func (u *User) handleDirectMessageEvent(event *bridge.DirectMessageEvent) {
 			u.MsgSpoofUser(u, event.Receiver.Nick, event.Text)
 		}
 	} else {
-		u.MsgSpoofUser(u.createUserFromInfo(event.Sender), event.Receiver.Nick, event.Text)
+		u.MsgSpoofUser(u.createUserFromInfo(event.Sender), u.Nick, event.Text)
 	}
 
 	if !u.v.GetBool(u.br.Protocol() + ".disableautoview") {


### PR DESCRIPTION
Currently the code creates the following IRC raw message (direct message sent from "buddy", to "me"):
> :buddy!buddy@https://chat.example.com PRIVMSG buddy :hi

However, according to the IRC spec rfc1459 4.4.1 (https://tools.ietf.org/html/rfc1459), direct messages should have my username set as the receiver.
i.e.
> :buddy!buddy@https://chat.example.com PRIVMSG me :hi

Fixes: #406

This code has been tested and confirmed to be working on v0.23

Thanks to @hloeung for helping verify the patch works.
