### PR TITLE
Add context for reactions

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -160,6 +160,7 @@ type ReactionAddEvent struct {
 	MessageID   string
 	Reaction    string
 	ChannelType string
+	ParentUser  *UserInfo
 	Message     string
 }
 

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -160,6 +160,7 @@ type ReactionAddEvent struct {
 	MessageID   string
 	Reaction    string
 	ChannelType string
+	Message     string
 }
 
 type ReactionRemoveEvent ReactionAddEvent

--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -1168,10 +1168,12 @@ func (m *Mattermost) handleReactionEvent(rmsg *model.WebSocketEvent) {
 		channelType = "D"
 	}
 
+	var parentUser *bridge.UserInfo
 	message := ""
 	if !m.v.GetBool("mattermost.hidereplies") {
 		parentPost, resp := m.mc.Client.GetPost(reaction.PostId, "")
 		if resp.Error == nil {
+			parentUser = m.GetUser(parentPost.UserId)
 			message = maybeShorten(parentPost.Message, m.v.GetInt("mattermost.shortenrepliesto"), "@", m.v.GetBool("mattermost.unicode"))
 		}
 	}
@@ -1186,6 +1188,7 @@ func (m *Mattermost) handleReactionEvent(rmsg *model.WebSocketEvent) {
 				Sender:      m.GetUser(reaction.UserId),
 				Reaction:    reaction.EmojiName,
 				ChannelType: channelType,
+				ParentUser:  parentUser,
 				Message:     message,
 			},
 		}
@@ -1198,6 +1201,7 @@ func (m *Mattermost) handleReactionEvent(rmsg *model.WebSocketEvent) {
 				Sender:      m.GetUser(reaction.UserId),
 				Reaction:    reaction.EmojiName,
 				ChannelType: channelType,
+				ParentUser:  parentUser,
 				Message:     message,
 			},
 		}

--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -1168,6 +1168,14 @@ func (m *Mattermost) handleReactionEvent(rmsg *model.WebSocketEvent) {
 		channelType = "D"
 	}
 
+	message := ""
+	if !m.v.GetBool("mattermost.hidereplies") {
+		parentPost, resp := m.mc.Client.GetPost(reaction.PostId, "")
+		if resp.Error == nil {
+			message = maybeShorten(parentPost.Message, m.v.GetInt("mattermost.shortenrepliesto"), "@", m.v.GetBool("mattermost.unicode"))
+		}
+	}
+
 	switch rmsg.Event {
 	case model.WEBSOCKET_EVENT_REACTION_ADDED:
 		event = &bridge.Event{
@@ -1178,6 +1186,7 @@ func (m *Mattermost) handleReactionEvent(rmsg *model.WebSocketEvent) {
 				Sender:      m.GetUser(reaction.UserId),
 				Reaction:    reaction.EmojiName,
 				ChannelType: channelType,
+				Message:     message,
 			},
 		}
 	case model.WEBSOCKET_EVENT_REACTION_REMOVED:
@@ -1189,6 +1198,7 @@ func (m *Mattermost) handleReactionEvent(rmsg *model.WebSocketEvent) {
 				Sender:      m.GetUser(reaction.UserId),
 				Reaction:    reaction.EmojiName,
 				ChannelType: channelType,
+				Message:     message,
 			},
 		}
 	}

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -367,7 +367,7 @@ func (u *User) handleReactionEvent(event interface{}) {
 	switch e := event.(type) {
 	case *bridge.ReactionAddEvent:
 		if !u.v.GetBool(u.br.Protocol() + ".hidereplies") {
-			nick := sanitizeNick(e.Sender.Nick)
+			nick := sanitizeNick(e.ParentUser.Nick)
 			message = fmt.Sprintf(" (re @%s: %s)", nick, e.Message)
 		}
 		text = "added reaction: "

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -362,8 +362,14 @@ func (u *User) handleReactionEvent(event interface{}) {
 		sender                                            *bridge.UserInfo
 	)
 
+	message := ""
+
 	switch e := event.(type) {
 	case *bridge.ReactionAddEvent:
+		if !u.v.GetBool(u.br.Protocol() + ".hidereplies") {
+			nick := sanitizeNick(e.Sender.Nick)
+			message = fmt.Sprintf(" (re @%s: %s)", nick, e.Message)
+		}
 		text = "added reaction: "
 		channelID = e.ChannelID
 		messageID = e.MessageID
@@ -371,6 +377,10 @@ func (u *User) handleReactionEvent(event interface{}) {
 		channelType = e.ChannelType
 		reaction = e.Reaction
 	case *bridge.ReactionRemoveEvent:
+		if !u.v.GetBool(u.br.Protocol() + ".hidereplies") {
+			nick := sanitizeNick(e.Sender.Nick)
+			message = fmt.Sprintf(" (re @%s: %s)", nick, e.Message)
+		}
 		text = "removed reaction: "
 		channelID = e.ChannelID
 		messageID = e.MessageID
@@ -381,7 +391,7 @@ func (u *User) handleReactionEvent(event interface{}) {
 
 	if channelType == "D" {
 		e := &bridge.DirectMessageEvent{
-			Text:      text + reaction,
+			Text:      text + reaction + message,
 			ChannelID: channelID,
 			Receiver:  u.UserInfo,
 			Sender:    sender,
@@ -397,7 +407,7 @@ func (u *User) handleReactionEvent(event interface{}) {
 	}
 
 	e := &bridge.ChannelMessageEvent{
-		Text:        text + reaction,
+		Text:        text + reaction + message,
 		ChannelID:   channelID,
 		ChannelType: channelType,
 		Sender:      sender,


### PR DESCRIPTION
Basically by showing the message emoji reactions was added to or removed from.

    |21:39 <hloeung> added reaction: smile (re @hloeung: Reply)
    |21:39 <hloeung> added reaction: +1 (re @hloeung: Test test test test test …) [↪@@pojqjum49p8bfmizfosr8g8f8c]
    |21:49 <hloeung> removed reaction: +1 (re @hloeung: Test) [↪@@aewp114y1tn55j6ahccd8qowca]

Also tested with non-mattermost message/thread IDs (so matterircd style 000-fff):

    |21:59 <hloeung> added reaction: +1 (re @hloeung: Test) [001]
    |22:00 <hloeung> @@001 +:thumbsup:
    |22:00 <hloeung> added reaction: thumbsup (re @hloeung: Test) [001]