### PR TITLE
Save message IDs and use them for local echo prevention

### DIFF
--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -145,6 +145,7 @@ func (s *Slack) Logout() error {
 func (s *Slack) createSlackMsgOption(text string) []slack.MsgOption {
 	np := slack.NewPostMessageParameters()
 	np.AsUser = true
+	np.Parse = "full"
 	// np.Username = u.User
 
 	var opts []slack.MsgOption


### PR DESCRIPTION
When message is POSTed Slack will reply with message ID (basically a timestamp). Keep track of them in msgLast (similar to mm-go-irckit) and check for own messages when receiving events from Slack. Then we can drop callback id in blocks (which fixes #341)

Also sets parse=full which makes mentions work again. I think Slack changed default some time ago.