### PR TITLE
Fix buffer flushing yet again

### DIFF
--- a/mm-go-irckit/user.go
+++ b/mm-go-irckit/user.go
@@ -181,8 +181,9 @@ func (u *User) Decode() {
 					// start timer now
 					t.Reset(time.Duration(bufferTimeout) * time.Millisecond)
 				} else {
-					re := regexp.MustCompile(`^(?:\@\@|s/)(?:[0-9a-f]{3}|[0-9a-z]{26}|!!)|^/`)
-					if strings.HasPrefix(msg.Trailing, "\x01ACTION") || re.MatchString(msg.Trailing) {
+					replyRe := regexp.MustCompile(`\@\@(?:[0-9a-z]{26}|[0-9a-f]{3}|!!)\s`)
+					modifyRe := regexp.MustCompile(`^s/(?:[0-9a-z]{26}|[0-9a-f]{3}|!!)?/`)
+					if strings.HasPrefix(msg.Trailing, "\x01ACTION") || replyRe.MatchString(msg.Trailing) || modifyRe.MatchString(msg.Trailing) {
 						// flush buffer
 						logger.Debug("flushing buffer because of /me, replies to threads, and message modifications")
 						u.BufferedMsg.Trailing = strings.TrimSpace(u.BufferedMsg.Trailing)


### PR DESCRIPTION
Yet another fix to bug introduced by commit bc88bb1. Still an issue with pasting paths causing the buffers to be flushed when it shouldn't (e.g. /srv/mydir). Instead, split it into two regexs to avoid confusion. One for replies to message/threads as well as reactions and the other for message modifications.