### PR TITLE
Handle SIGSEGV nil pointer for event.ParentUser

### DIFF
--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -367,7 +367,10 @@ func (u *User) handleReactionEvent(event interface{}) {
 	switch e := event.(type) {
 	case *bridge.ReactionAddEvent:
 		if !u.v.GetBool(u.br.Protocol() + ".hidereplies") {
-			nick := sanitizeNick(e.ParentUser.Nick)
+			nick := "(none)"
+			if e.ParentUser != nil {
+				nick = sanitizeNick(e.ParentUser.Nick)
+			}
 			message = fmt.Sprintf(" (re @%s: %s)", nick, e.Message)
 		}
 		text = "added reaction: "


### PR DESCRIPTION
@axinojolais ran into this issue where matterircd crashed with SIGSEGV:

    panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x46cd00]
    
    goroutine 50 [running]:
    github.com/42wim/matterircd/mm-go-irckit.(*User).handleReactionEvent(0xc0000b09a0, 0x4c7820, 0xc0002c0960)
            /home/matterircd/go/src/github.com/42wim/matterircd/mm-go-irckit/userbridge.go:370 +0x360
    github.com/42wim/matterircd/mm-go-irckit.(*User).handleEventChan(0xc0000b09a0)
            /home/matterircd/go/src/github.com/42wim/matterircd/mm-go-irckit/userbridge.go:95 +0x17e
    created by github.com/42wim/matterircd/mm-go-irckit.(*User).loginTo
            /home/matterircd/go/src/github.com/42wim/matterircd/mm-go-irckit/userbridge.go:814 +0x1b4

Not sure what triggered it, but this should guard and hopefully prevent crashes of this type.