### PR TITLE
Fix channel mentions and add option to disable channel mentions as IRC NOTICEs

### DIFF
--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -735,6 +735,7 @@ func (m *Mattermost) handleWsActionPost(rmsg *model.WebSocketEvent) {
 		return
 	}
 
+	replyMessage := ""
 	if data.ParentId != "" {
 		parentPost, resp := m.mc.Client.GetPost(data.ParentId, "")
 		if resp.Error != nil {
@@ -744,7 +745,7 @@ func (m *Mattermost) handleWsActionPost(rmsg *model.WebSocketEvent) {
 
 			if !m.v.GetBool("mattermost.hidereplies") {
 				parentMessage := maybeShorten(parentPost.Message, m.v.GetInt("mattermost.ShortenRepliesTo"), "@", m.v.GetBool("mattermost.unicode"))
-				data.Message = fmt.Sprintf("%s (re @%s: %s)", data.Message, parentGhost.Nick, parentMessage)
+				replyMessage = fmt.Sprintf(" (re @%s: %s)", parentGhost.Nick, parentMessage)
 			}
 		}
 	}
@@ -809,7 +810,7 @@ func (m *Mattermost) handleWsActionPost(rmsg *model.WebSocketEvent) {
 		return
 	}
 
-	msgs := strings.Split(data.Message, "\n")
+	msgs := strings.Split(data.Message+replyMessage, "\n")
 
 	channelType := ""
 	if t, ok := props["channel_type"].(string); ok {

--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -886,13 +886,18 @@ func (m *Mattermost) handleWsActionPost(rmsg *model.WebSocketEvent) {
 			}
 		case strings.Contains(data.Message, "@channel") || strings.Contains(data.Message, "@here") ||
 			strings.Contains(data.Message, "@all"):
+
+			messageType := "notice"
+			if m.v.GetBool("mattermost.disabledefaultmentions") {
+				messageType = ""
+			}
 			event := &bridge.Event{
 				Type: "channel_message",
 				Data: &bridge.ChannelMessageEvent{
 					Text:        msg,
 					ChannelID:   data.ChannelId,
 					Sender:      ghost,
-					MessageType: "notice",
+					MessageType: messageType,
 					ChannelType: channelType,
 					Files:       m.getFilesFromData(data),
 					MessageID:   data.Id,

--- a/matterircd.toml.example
+++ b/matterircd.toml.example
@@ -135,6 +135,9 @@ SuffixContext = false
 #This will show (mention yournick) after a message if it contains one of the words configured
 #in your mattermost "word that trigger mentions" notifications.
 ShowMentions = false
+# Channel wide default mentions @channel, @all, and @here are shown as IRC NOTICEs.
+# This disables that making them appear as normal PRIVMSGs.
+#DisableDefaultMentions = true
 
 # Path to file to store last viewed information. This is useful for replying only
 # the messages missed.


### PR DESCRIPTION
Fixes https://github.com/42wim/matterircd/issues/416

We fix it so only if the message contains channel mentions @{here,channel,all} rather than if the parent message:

    |21:37 -hloeung:#haw-test- @here Testing again [@@4f7tqoranpgd9bb98itfxt87qw]
    |21:37 <hloeung> This time replying, which shouldn't be an IRC NOTICE message but rather PRIVMSG (re @hloeung: @here Testing again) [↪@@4f7tqoranpgd9bb98itfxt87qw]

Also adds an option to allow disabling channel wide mentions. When enabled:

    |20:40 <hloeung> @here test [@@18qrfrwa9prk7y9hew49dtahio]

When disabled, which is the current behavior:

    |20:41 -hloeung:#haw-test- @here test [@@18qrfrwa9prk7y9hew49dtahio]