### PR TITLE
Fix ordering of events (such as code blocks)

### DIFF
--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -825,8 +825,6 @@ func (u *User) loginTo(protocol string) error {
 	u.User = info.User
 	u.MentionKeys = info.MentionKeys
 
-	go u.handleEventChan()
-
 	return nil
 }
 


### PR DESCRIPTION
Reported by @furai on IRC. This is due to having two event chan readers.