### PR TITLE
Don't show warning if lastViewedAt state file doesn't exist, also create it early

### DIFF
--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -965,6 +965,14 @@ func (u *User) loadLastViewedAt() map[string]int64 {
 		return make(map[string]int64)
 	}
 
+	if _, err := os.Stat(statePath); os.IsNotExist(err) {
+		logger.Debug("No saved lastViewedAt, using empty values")
+		lastViewedAt := make(map[string]int64)
+		// We also want to dump out/create the lastViewedAt state file.
+		saveLastViewedAtStateFile(statePath, lastViewedAt)
+		return lastViewedAt
+	}
+
 	staleDuration := u.v.GetString("mattermost.lastviewedstaleduration")
 	lastViewedAt, err := loadLastViewedAtStateFile(statePath, staleDuration)
 	if err != nil {


### PR DESCRIPTION
Mainly for https://github.com/42wim/matterircd/issues/421#issuecomment-810634715 where the warning about not being able to load the lastViewedAt state file can be confusing when it doesn't currently exist.