### PR TITLE
Use unbuffered channels to avoid out-of-order msgs. Fixes #426

### DIFF
--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -58,7 +58,7 @@ func NewUserBridge(c net.Conn, srv Server, cfg *viper.Viper) *User {
 	u.msgMap = make(map[string]map[string]int)
 	u.msgCounter = make(map[string]int)
 	u.updateCounter = make(map[string]time.Time)
-	u.eventChan = make(chan *bridge.Event, 1000)
+	u.eventChan = make(chan *bridge.Event)
 
 	// used for login
 	u.createService("mattermost", "loginservice")


### PR DESCRIPTION
IIUC, and per https://stackoverflow.com/a/25795236, the issue with out-of-order messages is due to switching to using buffered channels in https://github.com/42wim/matterircd/pull/383.