### PR TITLE
Preserve leading whitespace and for code blocks, new/empty lines. Fixes #420

### DIFF
--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -839,10 +839,6 @@ func (m *Mattermost) handleWsActionPost(rmsg *model.WebSocketEvent) {
 	}
 
 	for _, msg := range msgs {
-		if msg == "" {
-			continue
-		}
-
 		switch {
 		// DirectMessage
 		case channelType == "D":

--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -838,7 +838,16 @@ func (m *Mattermost) handleWsActionPost(rmsg *model.WebSocketEvent) {
 		dmchannel = name
 	}
 
+	codeBlock := false
 	for _, msg := range msgs {
+		if msg == "```" {
+			codeBlock = !codeBlock
+		}
+		// skip empty lines for anything not part of a code block.
+		if !codeBlock && msg == "" {
+			continue
+		}
+
 		switch {
 		// DirectMessage
 		case channelType == "D":

--- a/mm-go-irckit/channel.go
+++ b/mm-go-irckit/channel.go
@@ -131,11 +131,6 @@ func (ch *channel) Message(from *User, text string) {
 	text = wordwrap.String(text, 440)
 	lines := strings.Split(text, "\n")
 	for _, l := range lines {
-		l = strings.TrimSpace(l)
-		if len(l) == 0 {
-			continue
-		}
-
 		msg := &irc.Message{
 			Prefix:   from.Prefix(),
 			Command:  irc.PRIVMSG,
@@ -448,13 +443,7 @@ func (ch *channel) Len() int {
 func (ch *channel) Spoof(from string, text string, cmd string) {
 	text = wordwrap.String(text, 440)
 	lines := strings.Split(text, "\n")
-
 	for _, l := range lines {
-		l = strings.TrimSpace(l)
-		if len(l) == 0 {
-			continue
-		}
-
 		msg := &irc.Message{
 			Prefix:   &irc.Prefix{Name: from, User: from, Host: from},
 			Command:  cmd,
@@ -463,6 +452,7 @@ func (ch *channel) Spoof(from string, text string, cmd string) {
 		}
 
 		ch.mu.RLock()
+
 		for _, to := range ch.usersIdx {
 			to.Encode(msg)
 		}

--- a/mm-go-irckit/service.go
+++ b/mm-go-irckit/service.go
@@ -319,10 +319,6 @@ func scrollback(u *User, toUser *User, args []string, service string) {
 		}
 
 		for _, post := range strings.Split(p.Message, "\n") {
-			if post == "" {
-				continue
-			}
-
 			switch { // nolint:dupl
 			case u.v.GetString(u.br.Protocol()+".threadcontext") == "mattermost" && strings.HasPrefix(args[0], "#"):
 				threadMsgID := u.prefixContext("", p.Id, p.ParentId, "")

--- a/mm-go-irckit/service.go
+++ b/mm-go-irckit/service.go
@@ -318,7 +318,16 @@ func scrollback(u *User, toUser *User, args []string, service string) {
 			nick = botname
 		}
 
+		codeBlock := false
 		for _, post := range strings.Split(p.Message, "\n") {
+			if post == "```" {
+				codeBlock = !codeBlock
+			}
+			// skip empty lines for anything not part of a code block.
+			if !codeBlock && post == "" {
+				continue
+			}
+
 			switch { // nolint:dupl
 			case u.v.GetString(u.br.Protocol()+".threadcontext") == "mattermost" && strings.HasPrefix(args[0], "#"):
 				threadMsgID := u.prefixContext("", p.Id, p.ParentId, "")

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -646,7 +646,16 @@ func (u *User) addUserToChannelWorker(channels <-chan *bridge.ChannelInfo, throt
 				nick = botname
 			}
 
+			codeBlock := false
 			for _, post := range strings.Split(p.Message, "\n") {
+				if post == "```" {
+					codeBlock = !codeBlock
+				}
+				// skip empty lines for anything not part of a code block.
+				if !codeBlock && post == "" {
+					continue
+				}
+
 				if showReplayHdr {
 					date := ts.Format("2006-01-02 15:04:05")
 					channame := brchannel.Name

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -647,10 +647,6 @@ func (u *User) addUserToChannelWorker(channels <-chan *bridge.ChannelInfo, throt
 			}
 
 			for _, post := range strings.Split(p.Message, "\n") {
-				if post == "" {
-					continue
-				}
-
 				if showReplayHdr {
 					date := ts.Format("2006-01-02 15:04:05")
 					channame := brchannel.Name
@@ -665,7 +661,7 @@ func (u *User) addUserToChannelWorker(channels <-chan *bridge.ChannelInfo, throt
 				}
 
 				replayMsg := fmt.Sprintf("[%s] %s", ts.Format("15:04"), post)
-				if u.v.GetString(u.br.Protocol()+".threadcontext") == "mattermost" {
+				if (u.v.GetBool(u.br.Protocol()+".prefixcontext") || u.v.GetBool(u.br.Protocol()+".suffixcontext")) && u.v.GetString(u.br.Protocol()+".threadcontext") == "mattermost" {
 					threadMsgID := u.prefixContext("", p.Id, p.ParentId, "")
 					replayMsg = u.formatContextMessage(ts.Format("15:04"), threadMsgID, post)
 				}
@@ -707,13 +703,7 @@ func (u *User) MsgUser(toUser *User, msg string) {
 func (u *User) MsgSpoofUser(sender *User, rcvuser string, msg string) {
 	msg = wordwrap.String(msg, 440)
 	lines := strings.Split(msg, "\n")
-
 	for _, l := range lines {
-		l = strings.TrimSpace(l)
-		if len(l) == 0 {
-			continue
-		}
-
 		u.Encode(&irc.Message{
 			Prefix: &irc.Prefix{
 				Name: sender.Nick,


### PR DESCRIPTION
This fixes https://github.com/42wim/matterircd/issues/420

    ```
    Test
    
        Test 2 indent
    
            Test 3 indent again
    ```

Becomes:

    |23:49 <hloeung> ``` [q53f6qrotfremdiwc6bt1f891c]
    |23:49 <hloeung> Test [q53f6qrotfremdiwc6bt1f891c]
    |23:49 <hloeung> Test 2 indent [q53f6qrotfremdiwc6bt1f891c]
    |23:49 <hloeung> Test 3 indent again [q53f6qrotfremdiwc6bt1f891c]
    |23:49 <hloeung> ``` [q53f6qrotfremdiwc6bt1f891c]

Instead, we want to preserve indentation / leading whitespace as well as new lines so with PrefixContext, it will look as follows:

    |00:10 <hloeung> [obg5jhw51byafg1uapjp4883we] ```
    |00:10 <hloeung> [obg5jhw51byafg1uapjp4883we] Test
    |00:10 <hloeung> [obg5jhw51byafg1uapjp4883we]
    |00:10 <hloeung> [obg5jhw51byafg1uapjp4883we]     Test 2 indent
    |00:10 <hloeung> [obg5jhw51byafg1uapjp4883we]
    |00:10 <hloeung> [obg5jhw51byafg1uapjp4883we]         Test 3 indent again
    |00:10 <hloeung> [obg5jhw51byafg1uapjp4883we] ```

Also with SuffixContext:

    |00:09 <hloeung> ``` [51ou8bffkpyetmibrkm71c5w5c]
    |00:09 <hloeung> Test [51ou8bffkpyetmibrkm71c5w5c]
    |00:09 <hloeung>  [51ou8bffkpyetmibrkm71c5w5c]
    |00:09 <hloeung>     Test 2 indent [51ou8bffkpyetmibrkm71c5w5c]
    |00:09 <hloeung>  [51ou8bffkpyetmibrkm71c5w5c]
    |00:09 <hloeung>         Test 3 indent again [51ou8bffkpyetmibrkm71c5w5c]
    |00:09 <hloeung> ``` [51ou8bffkpyetmibrkm71c5w5c]
