### PR TITLE
Fix incorrect nick for reaction removal

### DIFF
--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -385,7 +385,10 @@ func (u *User) handleReactionEvent(event interface{}) {
 		reaction = e.Reaction
 	case *bridge.ReactionRemoveEvent:
 		if !u.v.GetBool(u.br.Protocol() + ".hidereplies") {
-			nick := sanitizeNick(e.Sender.Nick)
+			nick := "(none)"
+			if e.ParentUser != nil {
+				nick = sanitizeNick(e.ParentUser.Nick)
+			}
 			message = fmt.Sprintf(" (re @%s: %s)", nick, e.Message)
 		}
 		text = "removed reaction: "


### PR DESCRIPTION
    28/04 21:23 < bob> something something please ?
    28/04 21:23 < bob> @@!! actually, 2s
    28/04 21:23 <@stuart> [↪rjjmk…] added reaction: waiting (re @bob: actually, 2s …)
    28/04 21:23 <@stuart> [↪rjjmk…] removed reaction: waiting (re @stuart: actually, 2s …)

The "removed reaction" shows the incorrect user/nick of the message the reaction was made to (or removed from). Instead of stuart, it should have been bob just like the reaction add line before it.