### PR TITLE
Return ERR_NOTREGISTERED when trying to join before registration

### DIFF
--- a/mm-go-irckit/server.go
+++ b/mm-go-irckit/server.go
@@ -439,6 +439,8 @@ outerloop:
 				u.Real = msg.Trailing
 			case irc.PASS:
 				u.Pass = msg.Params
+			case irc.JOIN:
+				s.EncodeMessage(u, irc.ERR_NOTREGISTERED, []string{"*"}, "Please register first")
 			}
 
 			if u.Nick == "" || u.User == "" {


### PR DESCRIPTION
Newer versions of the IRC protocol support a message called CAP to negotiate capabilities, what the server can and cannot do

In order to implement this properly, the newest version of irssi (currently unreleased) sends out a JOIN command in order to see if the server has properly replied to the CAP message or not.

Since matterircd is the only ircd not responding with an error to this join message, irssi cannot connect to matterircd anymore. Instead the connection times out.

This patch fixes this by ensuring the join message returns an error if tried before the registration is complete