### PR TITLE
Use unbuffered eventChan for slack/mattermost. Fixes #426

### DIFF
--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -814,8 +814,10 @@ func (u *User) loginTo(protocol string) error {
 
 	switch protocol {
 	case "slack":
+		u.eventChan = make(chan *bridge.Event)
 		u.br, err = slack.New(u.v, u.Credentials, u.eventChan, u.addUsersToChannels)
 	case "mattermost":
+		u.eventChan = make(chan *bridge.Event)
 		u.br, _, err = mattermost.New(u.v, u.Credentials, u.eventChan, u.addUsersToChannels)
 	}
 


### PR DESCRIPTION
This should fix any unordered messages, but no idea why they are
unordered in the first place...