### PR TITLE
Allow overriding handshake timeout. Fixes #438

### DIFF
--- a/matterircd.toml.example
+++ b/matterircd.toml.example
@@ -24,6 +24,9 @@ gops = false
 #TLSKey = "/etc/pki/tls/matterircd/key.pem"
 #TLSCert = "/etc/pki/tls/matterircd/cer.pem"
 
+# Override handshake timeout (in seconds)
+#HandshakeTimeout = 10
+
 #PasteBufferTimeout specifies the amount of time in milliseconds that
 #messages get kept in matterircd internal buffer before being sent to
 #mattermost or slack.

--- a/mm-go-irckit/server.go
+++ b/mm-go-irckit/server.go
@@ -404,6 +404,10 @@ func (s *server) handshake(u *User) error {
 	u.Host = u.ResolveHost()
 	go u.Decode()
 
+	timeout := u.v.GetInt("HandshakeTimeout")
+	if timeout == 0 {
+		timeout = 10
+	}
 	// Consume N messages then give up.
 	i := handshakeMsgTolerance
 	// Read messages until we filled in USER details.
@@ -478,7 +482,7 @@ outerloop:
 			}
 
 			return err
-		case <-time.After(10 * time.Second):
+		case <-time.After(time.Duration(timeout) * time.Second):
 			return ErrHandshakeFailed
 		}
 	}


### PR DESCRIPTION
Just as the title says, allow overriding the default 10seconds handshake timeout - https://github.com/42wim/matterircd/issues/438