### PR TITLE
Fix segfault when bot user fetch fails

### DIFF
--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -676,10 +676,10 @@ func (s *Slack) getSlackUserFromMessage(rmsg *slack.MessageEvent) (*slack.User, 
 			if err != nil {
 				suser.Profile.DisplayName = "bot"
 				suser.Name = "bot"
+			} else {
+				suser.Profile.DisplayName = bot.Name
+				suser.Name = bot.Name
 			}
-
-			suser.Profile.DisplayName = bot.Name
-			suser.Name = bot.Name
 		}
 
 		return suser, nil


### PR DESCRIPTION
I just ran into this bug

```
slack-go/slack2021/06/15 13:33:02 websocket_managed_conn.go:387: Incoming Event: {"type":"message","subtype":"bot_message","text":"","suppress_notification":false,"bot_id":"B0A4JCWSK",...
2021/06/15 13:33:02 protocol error: received *http.http2GoAwayFrame before a SETTINGS frame
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x8705f9]

goroutine 291 [running]:
github.com/42wim/matterircd/bridge/slack.(*Slack).getSlackUserFromMessage(0xc0000a2600, 0xc0006f4000, 0x9e6c0b, 0x29, 0xc0002f53f0)
        /home/akolehma/go/src/github.com/42wim/matterircd/bridge/slack/slack.go:681 +0x2f9
github.com/42wim/matterircd/bridge/slack.(*Slack).handleSlackActionPost(0xc0000a2600, 0xc0006f4000)
        /home/akolehma/go/src/github.com/42wim/matterircd/bridge/slack/slack.go:753 +0x125
github.com/42wim/matterircd/bridge/slack.(*Slack).handleSlack(0xc0000a2600)
        /home/akolehma/go/src/github.com/42wim/matterircd/bridge/slack/slack.go:519 +0x465
created by github.com/42wim/matterircd/bridge/slack.(*Slack).loginToSlack
        /home/akolehma/go/src/github.com/42wim/matterircd/bridge/slack/slack.go:503 +0x32b
```

Looks like the code checked for error but then ignored the result :)
