### PR TITLE
Allow overriding the anti-idle channel and interval

### DIFF
--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -68,8 +68,18 @@ func (m *Mattermost) loginToMattermost(onWsConnect func()) (*matterclient.Client
 		mc.Credentials.NoTLS = true
 	}
 
-	// do anti idle on town-square, every installation should have this channel
 	mc.AntiIdle = !m.v.GetBool("mattermost.DisableAutoView") || m.v.GetBool("mattermost.ForceAntiIdle")
+	if mc.AntiIdle {
+		mc.AntiIdleChan = m.v.GetString("mattermost.AntiIdleChannel")
+		if mc.AntiIdleChan == "" {
+			// do anti idle on town-square, every installation should have this channel
+			mc.AntiIdleChan = "town-square"
+		}
+		mc.AntiIdleIntvl = m.v.GetInt("mattermost.AntiIdleInterval")
+		if mc.AntiIdleIntvl == 0 {
+			mc.AntiIdleIntvl = 60
+		}
+	}
 	mc.OnWsConnect = onWsConnect
 
 	if m.v.GetBool("debug") {

--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -69,17 +69,8 @@ func (m *Mattermost) loginToMattermost(onWsConnect func()) (*matterclient.Client
 	}
 
 	mc.AntiIdle = !m.v.GetBool("mattermost.DisableAutoView") || m.v.GetBool("mattermost.ForceAntiIdle")
-	if mc.AntiIdle {
-		mc.AntiIdleChan = m.v.GetString("mattermost.AntiIdleChannel")
-		if mc.AntiIdleChan == "" {
-			// do anti idle on town-square, every installation should have this channel
-			mc.AntiIdleChan = "town-square"
-		}
-		mc.AntiIdleIntvl = m.v.GetInt("mattermost.AntiIdleInterval")
-		if mc.AntiIdleIntvl == 0 {
-			mc.AntiIdleIntvl = 60
-		}
-	}
+	mc.AntiIdleChan = m.v.GetString("mattermost.AntiIdleChannel")
+	mc.AntiIdleIntvl = m.v.GetInt("mattermost.AntiIdleInterval")
 	mc.OnWsConnect = onWsConnect
 
 	if m.v.GetBool("debug") {

--- a/matterircd.toml.example
+++ b/matterircd.toml.example
@@ -102,6 +102,8 @@ PrefixMainTeam = false
 DisableAutoView = false
 # Force and enable anti-idle. Useful for when DisableAutoView.
 # ForceAntiIdle = true
+# AntiIdleChannel = "town-square"
+# AntiIdleInterval = 60
 
 # If users set a Nickname, matterircd could either choose that or the Username
 # to display in the IRC client. The option PreferNickname controls that, the

--- a/mm-go-irckit/server.go
+++ b/mm-go-irckit/server.go
@@ -234,7 +234,7 @@ func (s *server) Channel(channelID string) Channel {
 		if err != nil {
 			// don't error on our special channels
 			if !strings.HasPrefix(channelID, "&") {
-				logger.Errorf("didn't find channel %s: %s", channelID, err)
+				logger.Errorf("didn't find channel %s (%s): %s", channelID, name, err)
 			}
 			info = &bridge.ChannelInfo{}
 		}

--- a/pkg/matterclient/matterclient.go
+++ b/pkg/matterclient/matterclient.go
@@ -168,6 +168,10 @@ func (m *Client) Login() error {
 	go m.checkConnection(ctx)
 
 	if m.AntiIdle {
+		if m.AntiIdleChan == "" {
+			// do anti idle on town-square, every installation should have this channel
+			m.AntiIdleChan = "town-square"
+		}
 		channels := m.GetChannels()
 		for _, channel := range channels {
 			if channel.Name == m.AntiIdleChan {
@@ -711,8 +715,11 @@ func (m *Client) HandleRatelimit(name string, resp *model.Response) error {
 }
 
 func (m *Client) antiIdle(ctx context.Context, channelID string, interval int) {
-	m.logger.Debugf("starting antiIdle for %s every %d secs", channelID, interval)
+	if interval == 0 {
+		interval = 60
+	}
 
+	m.logger.Debugf("starting antiIdle for %s every %d secs", channelID, interval)
 	ticker := time.NewTicker(time.Second * time.Duration(interval))
 
 	for {


### PR DESCRIPTION
I want to be able to check messages I haven't read in the Town Square on a different device, but at the same time, have the anti-idle feature on. I have a separate test channel to use for anti-idling.

Since we're here, also allow overriding the anti-idle interval.