### PR TITLE
Addition and removal of user to/from team from system

### DIFF
--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -810,6 +810,12 @@ func (m *Mattermost) handleWsActionPost(rmsg *model.WebSocketEvent) {
 		return
 	}
 
+	if data.Type == "system_add_to_team" || data.Type == "system_remove_from_team" {
+		ghost = &bridge.UserInfo{
+			Nick: "system",
+		}
+	}
+
 	msgs := strings.Split(data.Message+replyMessage, "\n")
 
 	channelType := ""

--- a/mm-go-irckit/service.go
+++ b/mm-go-irckit/service.go
@@ -318,6 +318,10 @@ func scrollback(u *User, toUser *User, args []string, service string) {
 			nick = botname
 		}
 
+		if p.Type == "system_add_to_team" || p.Type == "system_remove_from_team" {
+			nick = "system"
+		}
+
 		codeBlock := false
 		for _, post := range strings.Split(p.Message, "\n") {
 			if post == "```" {
@@ -329,17 +333,17 @@ func scrollback(u *User, toUser *User, args []string, service string) {
 			}
 
 			switch { // nolint:dupl
-			case u.v.GetString(u.br.Protocol()+".threadcontext") == "mattermost" && strings.HasPrefix(args[0], "#"):
+			case u.v.GetString(u.br.Protocol()+".threadcontext") == "mattermost" && strings.HasPrefix(args[0], "#") && nick != "system":
 				threadMsgID := u.prefixContext("", p.Id, p.ParentId, "")
 				scrollbackMsg := u.formatContextMessage(ts.Format("2006-01-02 15:04"), threadMsgID, post)
+				spoof(nick, scrollbackMsg)
+			case strings.HasPrefix(args[0], "#"):
+				scrollbackMsg := "[" + ts.Format("2006-01-02 15:04") + "] " + post
 				spoof(nick, scrollbackMsg)
 			case u.v.GetString(u.br.Protocol()+".threadcontext") == "mattermost":
 				threadMsgID := u.prefixContext("", p.Id, p.ParentId, "")
 				scrollbackMsg := u.formatContextMessage(ts.Format("2006-01-02 15:04"), threadMsgID, post)
 				u.MsgSpoofUser(scrollbackUser, nick, scrollbackMsg)
-			case strings.HasPrefix(args[0], "#"):
-				scrollbackMsg := "[" + ts.Format("2006-01-02 15:04") + "] " + post
-				spoof(nick, scrollbackMsg)
 			default:
 				scrollbackMsg := "[" + ts.Format("2006-01-02 15:04") + "]" + " <" + nick + "> " + post
 				u.MsgSpoofUser(scrollbackUser, nick, scrollbackMsg)

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -270,7 +270,7 @@ func (u *User) handleChannelMessageEvent(event *bridge.ChannelMessageEvent) {
 		}
 	}
 
-	if u.v.GetBool(u.br.Protocol()+".prefixcontext") || u.v.GetBool(u.br.Protocol()+".suffixcontext") {
+	if (u.v.GetBool(u.br.Protocol()+".prefixcontext") || u.v.GetBool(u.br.Protocol()+".suffixcontext")) && u.Nick != "system" {
 		prefix := u.prefixContext(event.ChannelID, event.MessageID, event.ParentID, event.Event)
 		switch {
 		case u.v.GetBool(u.br.Protocol()+".prefixcontext") && strings.HasPrefix(event.Text, "\x01"):
@@ -649,6 +649,10 @@ func (u *User) addUserToChannelWorker(channels <-chan *bridge.ChannelInfo, throt
 				nick = botname
 			}
 
+			if p.Type == "system_add_to_team" || p.Type == "system_remove_from_team" {
+				nick = "system"
+			}
+
 			codeBlock := false
 			for _, post := range strings.Split(p.Message, "\n") {
 				if post == "```" {
@@ -673,7 +677,7 @@ func (u *User) addUserToChannelWorker(channels <-chan *bridge.ChannelInfo, throt
 				}
 
 				replayMsg := fmt.Sprintf("[%s] %s", ts.Format("15:04"), post)
-				if (u.v.GetBool(u.br.Protocol()+".prefixcontext") || u.v.GetBool(u.br.Protocol()+".suffixcontext")) && u.v.GetString(u.br.Protocol()+".threadcontext") == "mattermost" {
+				if (u.v.GetBool(u.br.Protocol()+".prefixcontext") || u.v.GetBool(u.br.Protocol()+".suffixcontext")) && u.v.GetString(u.br.Protocol()+".threadcontext") == "mattermost" && nick != "system" {
 					threadMsgID := u.prefixContext("", p.Id, p.ParentId, "")
 					replayMsg = u.formatContextMessage(ts.Format("15:04"), threadMsgID, post)
 				}

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -21,6 +21,8 @@ import (
 	"github.com/spf13/viper"
 )
 
+const systemUser = "system"
+
 type UserBridge struct {
 	Srv         Server
 	Credentials bridge.Credentials
@@ -183,8 +185,8 @@ func (u *User) handleChannelAddEvent(event *bridge.ChannelAddEvent) {
 
 		ch.Join(ghost)
 
-		if event.Adder != nil && added.Nick != event.Adder.Nick && event.Adder.Nick != "system" {
-			ch.SpoofMessage("system", "added "+added.Nick+" to the channel by "+event.Adder.Nick)
+		if event.Adder != nil && added.Nick != event.Adder.Nick && event.Adder.Nick != systemUser {
+			ch.SpoofMessage(systemUser, "added "+added.Nick+" to the channel by "+event.Adder.Nick)
 		}
 	}
 
@@ -207,8 +209,8 @@ func (u *User) handleChannelRemoveEvent(event *bridge.ChannelRemoveEvent) {
 
 		ch.Part(ghost, "")
 
-		if event.Remover != nil && removed.Nick != event.Remover.Nick && event.Remover.Nick != "system" {
-			ch.SpoofMessage("system", "removed "+removed.Nick+" from the channel by "+event.Remover.Nick)
+		if event.Remover != nil && removed.Nick != event.Remover.Nick && event.Remover.Nick != systemUser {
+			ch.SpoofMessage(systemUser, "removed "+removed.Nick+" from the channel by "+event.Remover.Nick)
 		}
 	}
 	u.saveLastViewedAt(event.ChannelID)
@@ -270,7 +272,7 @@ func (u *User) handleChannelMessageEvent(event *bridge.ChannelMessageEvent) {
 		}
 	}
 
-	if (u.v.GetBool(u.br.Protocol()+".prefixcontext") || u.v.GetBool(u.br.Protocol()+".suffixcontext")) && u.Nick != "system" {
+	if (u.v.GetBool(u.br.Protocol()+".prefixcontext") || u.v.GetBool(u.br.Protocol()+".suffixcontext")) && u.Nick != systemUser {
 		prefix := u.prefixContext(event.ChannelID, event.MessageID, event.ParentID, event.Event)
 		switch {
 		case u.v.GetBool(u.br.Protocol()+".prefixcontext") && strings.HasPrefix(event.Text, "\x01"):
@@ -650,7 +652,7 @@ func (u *User) addUserToChannelWorker(channels <-chan *bridge.ChannelInfo, throt
 			}
 
 			if p.Type == "system_add_to_team" || p.Type == "system_remove_from_team" {
-				nick = "system"
+				nick = systemUser
 			}
 
 			codeBlock := false
@@ -677,7 +679,7 @@ func (u *User) addUserToChannelWorker(channels <-chan *bridge.ChannelInfo, throt
 				}
 
 				replayMsg := fmt.Sprintf("[%s] %s", ts.Format("15:04"), post)
-				if (u.v.GetBool(u.br.Protocol()+".prefixcontext") || u.v.GetBool(u.br.Protocol()+".suffixcontext")) && u.v.GetString(u.br.Protocol()+".threadcontext") == "mattermost" && nick != "system" {
+				if (u.v.GetBool(u.br.Protocol()+".prefixcontext") || u.v.GetBool(u.br.Protocol()+".suffixcontext")) && u.v.GetString(u.br.Protocol()+".threadcontext") == "mattermost" && nick != systemUser {
 					threadMsgID := u.prefixContext("", p.Id, p.ParentId, "")
 					replayMsg = u.formatContextMessage(ts.Format("15:04"), threadMsgID, post)
 				}


### PR DESCRIPTION
Rather than this:

    |14:07 <myuser> myuser removed from the team.

We get this:

    |14:07 <system> myuser removed from the team.

This better matches with what's shown via the Mattermost web UI:

    System 00:23
    @myuser was removed from the team.

As well as when users are added or removed from channels per https://github.com/42wim/matterircd/blob/master/mm-go-irckit/userbridge.go#L187 :

    |00:56 <system> added myuser to the channel by hloeung