### PR TITLE
Add ootrace option to help debug out of order

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -125,6 +125,7 @@ type ChannelMessageEvent struct {
 	MessageID   string
 	Event       string
 	ParentID    string
+	Multiline   bool
 }
 
 type ChannelTopicEvent struct {

--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -937,7 +937,12 @@ func (m *Mattermost) handleWsActionPost(rmsg *model.WebSocketEvent) {
 					MessageID:   data.Id,
 					Event:       rmsg.Event,
 					ParentID:    data.ParentId,
+					Multiline:   len(msgs) > 1,
 				},
+			}
+
+			if len(msgs) > 1 && m.v.GetBool("ootrace") {
+				logger.Infof("OOTRACE: sending msg %s to eventChan on %d: %d", msg, time.Now().UnixNano(), len(m.eventChan))
 			}
 
 			m.eventChan <- event
@@ -949,6 +954,10 @@ func (m *Mattermost) handleWsActionPost(rmsg *model.WebSocketEvent) {
 	}
 
 	m.handleFileEvent(channelType, ghost, data, rmsg)
+
+	if len(msgs) > 1 && m.v.GetBool("ootrace") {
+		logger.Infof("OOTRACE: %s sent %v", m.mc.GetUser(data.UserId).Username, data.Message)
+	}
 
 	logger.Debugf("handleWsActionPost() user %s sent %s", m.mc.GetUser(data.UserId).Username, data.Message)
 	logger.Debugf("%#v", data)

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -294,6 +294,9 @@ func (u *User) handleChannelMessageEvent(event *bridge.ChannelMessageEvent) {
 	case "notice":
 		ch.SpoofNotice(nick, event.Text)
 	default:
+		if u.v.GetBool("ootrace") && event.Multiline {
+			logger.Infof("OOTRACE: got msg %s on %d", event.Text, time.Now().UnixNano())
+		}
 		ch.SpoofMessage(nick, event.Text)
 	}
 

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -67,7 +67,8 @@ func NewUserBridge(c net.Conn, srv Server, cfg *viper.Viper, db *bolt.DB) *User 
 	u.msgMap = make(map[string]map[string]int)
 	u.msgCounter = make(map[string]int)
 	u.updateCounter = make(map[string]time.Time)
-	u.eventChan = make(chan *bridge.Event, 1000)
+	logger.Info("OOTRACE: creating non-buffered eventchan on start-up")
+	u.eventChan = make(chan *bridge.Event)
 
 	// used for login
 	u.createService("mattermost", "loginservice")
@@ -981,10 +982,8 @@ func (u *User) loginTo(protocol string) error {
 
 	switch protocol {
 	case "slack":
-		u.eventChan = make(chan *bridge.Event)
 		u.br, err = slack.New(u.v, u.Credentials, u.eventChan, u.addUsersToChannels)
 	case "mattermost":
-		u.eventChan = make(chan *bridge.Event)
 		if strings.HasPrefix(u.getMattermostVersion(), "6.") {
 			u.br, _, err = mattermost6.New(u.v, u.Credentials, u.eventChan, u.addUsersToChannels)
 		} else {


### PR DESCRIPTION
Add `ootrace=true` (same way as `trace=true`) in your matterircd.toml
You don't need to run with full `--debug`, it'll show timestamps of every (multiline) message going to the eventchan and received from the eventchan on the irc side.