### PR TITLE
Allow overriding client timeout

### DIFF
--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -73,17 +73,16 @@ func (m *Mattermost) loginToMattermost(onWsConnect func()) (*matterclient.Client
 	mc.AntiIdleIntvl = m.v.GetInt("mattermost.AntiIdleInterval")
 	mc.OnWsConnect = onWsConnect
 
+	mc.Timeout = m.v.GetInt("ClientTimeout")
+	if mc.Timeout == 0 {
+		mc.Timeout = 10
+	}
+
 	if m.v.GetBool("debug") {
 		mc.SetLogLevel("debug")
 	}
 
 	mc.Credentials.SkipTLSVerify = m.v.GetBool("mattermost.SkipTLSVerify")
-
-	/*
-		if m.v.GetBool("debug") {
-			mc.SetLogLevel("debug")
-		}
-	*/
 
 	logger.Infof("login as %s (team: %s) on %s", m.credentials.Login, m.credentials.Team, m.credentials.Server)
 

--- a/matterircd.toml.example
+++ b/matterircd.toml.example
@@ -26,6 +26,8 @@ gops = false
 
 # Override handshake timeout (in seconds)
 #HandshakeTimeout = 10
+# Override client timeout (in seconds)
+#ClientTimeout = 10
 
 #PasteBufferTimeout specifies the amount of time in milliseconds that
 #messages get kept in matterircd internal buffer before being sent to

--- a/pkg/matterclient/matterclient.go
+++ b/pkg/matterclient/matterclient.go
@@ -71,6 +71,7 @@ type Client struct {
 	WsConnected   bool
 	OnWsConnect   func()
 	reconnectBusy bool
+	Timeout       int
 
 	logger      *logrus.Entry
 	rootLogger  *logrus.Logger
@@ -224,7 +225,7 @@ func (m *Client) initClient(b *backoff.Backoff) error {
 		},
 		Proxy: http.ProxyFromEnvironment,
 	}
-	m.Client.HttpClient.Timeout = time.Second * 10
+	m.Client.HttpClient.Timeout = time.Second * time.Duration(m.Timeout)
 
 	// handle MMAUTHTOKEN and personal token
 	if err := m.handleLoginToken(); err != nil {


### PR DESCRIPTION
Increasing this reduces duplicate messages or errors about not finding
parent thread ID in time when either Mattermost server is under heavy
or slow client connection to the Mattermost server.