### PR TITLE
Fix possible panic in mattermost

### DIFF
--- a/vendor/github.com/matterbridge/matterclient/matterclient.go
+++ b/vendor/github.com/matterbridge/matterclient/matterclient.go
@@ -714,6 +714,10 @@ func (m *Client) SetLogLevel(level string) {
 }
 
 func (m *Client) HandleRatelimit(name string, resp *model.Response) error {
+	if resp == nil {
+		return fmt.Errorf("Got a nil model response from %s", name)
+	}
+
 	if resp.StatusCode != 429 {
 		return fmt.Errorf("StatusCode error: %d", resp.StatusCode)
 	}


### PR DESCRIPTION
Fixes #457 
This panic shows that `resp` can be nil, which is strange to get an nil response here. 
Return an error now.