### PR TITLE
Fix multiline replies to threads

### DIFF
--- a/mm-go-irckit/server_commands.go
+++ b/mm-go-irckit/server_commands.go
@@ -582,7 +582,7 @@ func parseModifyMsg(u *User, msg *irc.Message, channelID string) bool {
 }
 
 func parseThreadID(u *User, msg *irc.Message, channelID string) (string, string) {
-	re := regexp.MustCompile(`^\@\@(?:(!!|[0-9a-f]{3}|[0-9a-z]{26})\s)(.*)`)
+	re := regexp.MustCompile(`(?s)^\@\@(?:(!!|[0-9a-f]{3}|[0-9a-z]{26})\s)(.*)`)
 	matches := re.FindStringSubmatch(msg.Trailing)
 	if len(matches) == 0 {
 		return "", ""


### PR DESCRIPTION
With commit 4215119a0722506cb43fa2331619b683de05efb4, when replying to threads with a multi-line post such as:

    ```
    Test 1
    Test 2
    Test 3
    ```

Only the first line is used, so the message becomes just:

    ```

This fixes that.