### PR TITLE
Ensure prefixcontext/suffixcontent shown for all lines in a multi-line message

### DIFF
--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -844,16 +844,7 @@ func (m *Mattermost) handleWsActionPost(rmsg *model.WebSocketEvent) {
 		dmchannel = name
 	}
 
-	codeBlock := false
 	for _, msg := range msgs {
-		if msg == "```" {
-			codeBlock = !codeBlock
-		}
-		// skip empty lines for anything not part of a code block.
-		if !codeBlock && msg == "" {
-			continue
-		}
-
 		switch {
 		// DirectMessage
 		case channelType == "D":

--- a/bridge/mattermost6/mattermost.go
+++ b/bridge/mattermost6/mattermost.go
@@ -854,16 +854,7 @@ func (m *Mattermost) handleWsActionPost(rmsg *model.WebSocketEvent) {
 		dmchannel = name
 	}
 
-	codeBlock := false
 	for _, msg := range msgs {
-		if strings.HasPrefix(msg, "```") || strings.Contains(msg, "\n```") {
-			codeBlock = !codeBlock
-		}
-		// skip empty lines for anything not part of a code block.
-		if !codeBlock {
-			msg = strings.ReplaceAll(msg, "\n\n", "\n")
-		}
-
 		switch {
 		// DirectMessage
 		case channelType == "D":

--- a/matterircd.toml.example
+++ b/matterircd.toml.example
@@ -140,6 +140,8 @@ SuffixContext = false
 #ThreadContext = "mattermost"
 # Similar to the above, but also show the message post IDs in addition to the parent thread ID.
 #ThreadContext = "mattermost+post"
+#Hide Context for multi-line messages and only show it at the end.
+HideContextMulti = false
 
 #This will show (mention yournick) after a message if it contains one of the words configured
 #in your mattermost "word that trigger mentions" notifications.

--- a/matterircd.toml.example
+++ b/matterircd.toml.example
@@ -140,8 +140,8 @@ SuffixContext = false
 #ThreadContext = "mattermost"
 # Similar to the above, but also show the message post IDs in addition to the parent thread ID.
 #ThreadContext = "mattermost+post"
-#Hide Context for multi-line messages and only show it at the end.
-HideContextMulti = false
+#Show Context for multi-line messages and only show it at the end.
+ShowContextMulti = false
 
 #This will show (mention yournick) after a message if it contains one of the words configured
 #in your mattermost "word that trigger mentions" notifications.

--- a/mm-go-irckit/channel.go
+++ b/mm-go-irckit/channel.go
@@ -67,10 +67,10 @@ type Channel interface {
 	String() string
 
 	// Spoof message
-	SpoofMessage(from string, text string)
+	SpoofMessage(from string, text string, maxlen ...int)
 
 	// Spoof notice
-	SpoofNotice(from string, text string)
+	SpoofNotice(from string, text string, maxlen ...int)
 
 	IsPrivate() bool
 }
@@ -440,8 +440,12 @@ func (ch *channel) Len() int {
 	return len(ch.usersIdx)
 }
 
-func (ch *channel) Spoof(from string, text string, cmd string) {
-	text = wordwrap.String(text, 440)
+func (ch *channel) Spoof(from string, text string, cmd string, maxlen ...int) {
+	if len(maxlen) == 0 {
+		text = wordwrap.String(text, 440)
+	} else {
+		text = wordwrap.String(text, maxlen[0])
+	}
 	lines := strings.Split(text, "\n")
 	for _, l := range lines {
 		msg := &irc.Message{
@@ -461,12 +465,20 @@ func (ch *channel) Spoof(from string, text string, cmd string) {
 	}
 }
 
-func (ch *channel) SpoofMessage(from string, text string) {
-	ch.Spoof(from, text, irc.PRIVMSG)
+func (ch *channel) SpoofMessage(from string, text string, maxlen ...int) {
+	if len(maxlen) == 0 {
+		ch.Spoof(from, text, irc.PRIVMSG, 440)
+	} else {
+		ch.Spoof(from, text, irc.PRIVMSG, maxlen[0])
+	}
 }
 
-func (ch *channel) SpoofNotice(from string, text string) {
-	ch.Spoof(from, text, irc.NOTICE)
+func (ch *channel) SpoofNotice(from string, text string, maxlen ...int) {
+	if len(maxlen) == 0 {
+		ch.Spoof(from, text, irc.NOTICE, 440)
+	} else {
+		ch.Spoof(from, text, irc.NOTICE, maxlen[0])
+	}
 }
 
 func (ch *channel) IsPrivate() bool {

--- a/mm-go-irckit/channel.go
+++ b/mm-go-irckit/channel.go
@@ -441,24 +441,20 @@ func (ch *channel) Len() int {
 }
 
 func (ch *channel) Spoof(from string, text string, cmd string) {
-	text = wordwrap.String(text, 440)
-	lines := strings.Split(text, "\n")
-	for _, l := range lines {
-		msg := &irc.Message{
-			Prefix:   &irc.Prefix{Name: from, User: from, Host: from},
-			Command:  cmd,
-			Params:   []string{ch.name},
-			Trailing: l + "\n",
-		}
-
-		ch.mu.RLock()
-
-		for _, to := range ch.usersIdx {
-			to.Encode(msg)
-		}
-
-		ch.mu.RUnlock()
+	msg := &irc.Message{
+		Prefix:   &irc.Prefix{Name: from, User: from, Host: from},
+		Command:  cmd,
+		Params:   []string{ch.name},
+		Trailing: text,
 	}
+
+	ch.mu.RLock()
+
+	for _, to := range ch.usersIdx {
+		to.Encode(msg) //nolint:errcheck
+	}
+
+	ch.mu.RUnlock()
 }
 
 func (ch *channel) SpoofMessage(from string, text string) {

--- a/mm-go-irckit/channel.go
+++ b/mm-go-irckit/channel.go
@@ -441,20 +441,24 @@ func (ch *channel) Len() int {
 }
 
 func (ch *channel) Spoof(from string, text string, cmd string) {
-	msg := &irc.Message{
-		Prefix:   &irc.Prefix{Name: from, User: from, Host: from},
-		Command:  cmd,
-		Params:   []string{ch.name},
-		Trailing: text,
+	text = wordwrap.String(text, 440)
+	lines := strings.Split(text, "\n")
+	for _, l := range lines {
+		msg := &irc.Message{
+			Prefix:   &irc.Prefix{Name: from, User: from, Host: from},
+			Command:  cmd,
+			Params:   []string{ch.name},
+			Trailing: l + "\n",
+		}
+
+		ch.mu.RLock()
+
+		for _, to := range ch.usersIdx {
+			to.Encode(msg)
+		}
+
+		ch.mu.RUnlock()
 	}
-
-	ch.mu.RLock()
-
-	for _, to := range ch.usersIdx {
-		to.Encode(msg) //nolint:errcheck
-	}
-
-	ch.mu.RUnlock()
 }
 
 func (ch *channel) SpoofMessage(from string, text string) {

--- a/mm-go-irckit/service.go
+++ b/mm-go-irckit/service.go
@@ -338,7 +338,7 @@ func scrollback(u *User, toUser *User, args []string, service string) {
 	}
 
 	var channelID string
-	var spoof func(string, string)
+	var spoof func(string, string, ...int)
 	scrollbackUser, exists := u.Srv.HasUser(args[0])
 
 	switch {
@@ -449,7 +449,7 @@ func scrollback6(u *User, toUser *User, args []string, service string) {
 	}
 
 	var channelID string
-	var spoof func(string, string)
+	var spoof func(string, string, ...int)
 	scrollbackUser, exists := u.Srv.HasUser(args[0])
 
 	switch {

--- a/mm-go-irckit/service.go
+++ b/mm-go-irckit/service.go
@@ -383,16 +383,7 @@ func scrollback(u *User, toUser *User, args []string, service string) {
 			nick = "system"
 		}
 
-		codeBlock := false
 		for _, post := range strings.Split(p.Message, "\n") {
-			if post == "```" {
-				codeBlock = !codeBlock
-			}
-			// skip empty lines for anything not part of a code block.
-			if !codeBlock && post == "" {
-				continue
-			}
-
 			switch { // nolint:dupl
 			case (u.v.GetString(u.br.Protocol()+".threadcontext") == "mattermost" || u.v.GetString(u.br.Protocol()+".threadcontext") == "mattermost+post") && strings.HasPrefix(args[0], "#") && nick != "system":
 				threadMsgID := u.prefixContext("", p.Id, p.ParentId, "")
@@ -503,16 +494,7 @@ func scrollback6(u *User, toUser *User, args []string, service string) {
 			nick = "system"
 		}
 
-		codeBlock := false
 		for _, post := range strings.Split(p.Message, "\n") {
-			if post == "```" {
-				codeBlock = !codeBlock
-			}
-			// skip empty lines for anything not part of a code block.
-			if !codeBlock && post == "" {
-				continue
-			}
-
 			switch { // nolint:dupl
 			case (u.v.GetString(u.br.Protocol()+".threadcontext") == "mattermost" || u.v.GetString(u.br.Protocol()+".threadcontext") == "mattermost+post") && strings.HasPrefix(args[0], "#") && nick != "system":
 				threadMsgID := u.prefixContext("", p.Id, p.RootId, "")

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -905,16 +905,20 @@ func (u *User) MsgUser(toUser *User, msg string) {
 }
 
 func (u *User) MsgSpoofUser(sender *User, rcvuser string, msg string) {
-	u.Encode(&irc.Message{ //nolint:errcheck
-		Prefix: &irc.Prefix{
-			Name: sender.Nick,
-			User: sender.Nick,
-			Host: sender.Host,
-		},
-		Command:  irc.PRIVMSG,
-		Params:   []string{rcvuser},
-		Trailing: msg,
-	})
+	msg = wordwrap.String(msg, 440)
+	lines := strings.Split(msg, "\n")
+	for _, l := range lines {
+		u.Encode(&irc.Message{
+			Prefix: &irc.Prefix{
+				Name: sender.Nick,
+				User: sender.Nick,
+				Host: sender.Host,
+			},
+			Command:  irc.PRIVMSG,
+			Params:   []string{rcvuser},
+			Trailing: l + "\n",
+		})
+	}
 }
 
 func (u *User) syncChannel(id string, name string) {

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -139,9 +139,20 @@ func (u *User) handleDirectMessageEvent(event *bridge.DirectMessageEvent) {
 		}
 	}
 
+	codeBlock := false
 	text := wordwrap.String(event.Text, 440)
 	lines := strings.Split(text, "\n")
 	for idx, text := range lines {
+		if text == "```" {
+			codeBlock = !codeBlock
+		}
+		// skip empty lines for anything not part of a code block.
+		if !codeBlock && text == "" {
+			continue
+		} else if text == "" {
+			text = " "
+		}
+
 		showContext := u.v.GetBool(u.br.Protocol()+".prefixcontext") || u.v.GetBool(u.br.Protocol()+".suffixcontext")
 
 		if showContext && u.v.GetBool(u.br.Protocol()+".hidecontextmulti") && idx != len(lines)-1 {
@@ -288,9 +299,20 @@ func (u *User) handleChannelMessageEvent(event *bridge.ChannelMessageEvent) {
 		}
 	}
 
+	codeBlock := false
 	text := wordwrap.String(event.Text, 440)
 	lines := strings.Split(text, "\n")
 	for idx, text := range lines {
+		if text == "```" {
+			codeBlock = !codeBlock
+		}
+		// skip empty lines for anything not part of a code block.
+		if !codeBlock && text == "" {
+			continue
+		} else if text == "" {
+			text = " "
+		}
+
 		showContext := (u.v.GetBool(u.br.Protocol()+".prefixcontext") || u.v.GetBool(u.br.Protocol()+".suffixcontext")) && u.Nick != systemUser
 
 		if showContext && u.v.GetBool(u.br.Protocol()+".hidecontextmulti") && idx != len(lines)-1 {
@@ -712,16 +734,7 @@ func (u *User) addUserToChannelWorker(channels <-chan *bridge.ChannelInfo, throt
 				nick = systemUser
 			}
 
-			codeBlock := false
 			for _, post := range strings.Split(p.Message, "\n") {
-				if post == "```" {
-					codeBlock = !codeBlock
-				}
-				// skip empty lines for anything not part of a code block.
-				if !codeBlock && post == "" {
-					continue
-				}
-
 				if showReplayHdr {
 					date := ts.Format("2006-01-02 15:04:05")
 					if brchannel.DM {
@@ -837,16 +850,7 @@ func (u *User) addUserToChannelWorker6(channels <-chan *bridge.ChannelInfo, thro
 				nick = systemUser
 			}
 
-			codeBlock := false
 			for _, post := range strings.Split(p.Message, "\n") {
-				if post == "```" {
-					codeBlock = !codeBlock
-				}
-				// skip empty lines for anything not part of a code block.
-				if !codeBlock && post == "" {
-					continue
-				}
-
 				if showReplayHdr {
 					date := ts.Format("2006-01-02 15:04:05")
 					channame := brchannel.Name


### PR DESCRIPTION
With the new no splitting multi-line messages in PR #482, multi-line messages are displayed as:

```
|20:09 <hloeung> Test One
|20:09 <hloeung> Test Two
|20:09 <hloeung> Test Three [c9ouoenfkprajc6o96zdp9z87y]
|20:16 <hloeung> Test One
|20:16 <hloeung> Test Two
|20:16 <hloeung> Test Three (re @hloeung: Test One Test Two Test …) [↪c9ouoenfkprajc6o96zdp9z87y,ak8gwopx4jnqbjf5ipnrtifyrc]
```

Unfortunately, it means using tools such as grepping won't show all the lines as part of the message. This fixes that:

```
|20:48 <hloeung> Test One [↪c9ouoenfkprajc6o96zdp9z87y,6wfxbuie3ty8x84ya4fpj8cabr]
|20:48 <hloeung> Test Two [↪c9ouoenfkprajc6o96zdp9z87y,6wfxbuie3ty8x84ya4fpj8cabr]
|20:48 <hloeung> Test Three (re @hloeung: Test One Test Two Test …) [↪c9ouoenfkprajc6o96zdp9z87y,6wfxbuie3ty8x84ya4fpj8cabr]
```

```
|20:50 <hloeung> Test One [002->001]
|20:50 <hloeung> Test Two [003->001]
|20:50 <hloeung> Test Three (re @hloeung: Test One Test Two Test …) [004->001]
|20:51 <hloeung> Test One [005->001]
|20:51 <hloeung> Test Two [006->001]
|20:51 <hloeung> Test Three (re @hloeung: Test One Test Two Test …) [007->001]
|20:51 <hloeung> Test [008]
|20:51 <hloeung> @@008 test [↪008]
```

```
|20:51 <hloeung> [↪c9ouoenfkprajc6o96zdp9z87y,gcopf88mcif1zdhjyscikrtscw] Test One
|20:51 <hloeung> [↪c9ouoenfkprajc6o96zdp9z87y,gcopf88mcif1zdhjyscikrtscw] Test Two
|20:51 <hloeung> [↪c9ouoenfkprajc6o96zdp9z87y,gcopf88mcif1zdhjyscikrtscw] Test Three (re @hloeung: Test One Test Two Test …)
```

```
|20:52 <hloeung> [↪c9ouoenfkprajc6o96zdp9z87y] Test One
|20:52 <hloeung> [↪c9ouoenfkprajc6o96zdp9z87y] Test Two
|20:52 <hloeung> [↪c9ouoenfkprajc6o96zdp9z87y] Test Three (re @hloeung: Test One Test Two Test …)
```