### PR TITLE
Fix fetching list of channels

### DIFF
--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -808,7 +808,7 @@ func (u *User) addUserToChannelWorker6(channels <-chan *bridge.ChannelInfo, thro
 		if postlist == nil {
 			// if the channel is not from the primary team id, we can't get posts
 			if brchannel.TeamID == u.br.GetMe().TeamID {
-				logger.Errorf("something wrong with getPostsSince for %s for channel %s (%s)", u.Nick, brchannel.ID, brchannel.Name)
+				logger.Errorf("something wrong with getPostsSince for %s for channel %s (%s)", u.Nick, channame, brchannel.ID)
 			}
 			continue
 		}


### PR DESCRIPTION
In addition to https://github.com/42wim/matterircd/pull/490, this fixes the retrieval of the list of the list of channels.

Per https://github.com/42wim/matterircd/issues/243 & https://github.com/42wim/matterircd/issues/248, the Mattermost server has a hardcoded maximum page limit of 200. So when adding debugging output, I get:
```
[2022-11-05T13:54:39+11:00]  INFO matterclient: found 158 channels for user in team canonical
[2022-11-05T13:54:39+11:00]  INFO matterclient: found 200 public channels in team canonical
```

With this, we get higher numbers:
```
[2022-11-05T14:14:50+11:00]  INFO matterclient: found 158 channels for user in team canonical
[2022-11-05T14:14:55+11:00]  INFO matterclient: found 1116 public channels in team canonical
```

This is also what's causing https://github.com/42wim/matterircd/issues/479