### PR TITLE
Fix splitting of lines for ACTIONs

### DIFF
--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -1295,7 +1295,7 @@ func (u *User) handleMessageThreadContext(channelID, messageID, parentID, event,
 	case u.v.GetBool(u.br.Protocol()+".prefixcontext") && strings.HasPrefix(text, "\x01"):
 		prefix = u.prefixContext(channelID, messageID, parentID, event) + " "
 		newText = strings.Replace(text, "\x01ACTION ", "\x01ACTION "+prefix, 1)
-		maxlen = len(text)
+		maxlen = len(newText)
 	case u.v.GetBool(u.br.Protocol()+".prefixcontext") && u.v.GetBool(u.br.Protocol()+".showcontextmulti"):
 		prefix = u.prefixContext(channelID, messageID, parentID, event) + " "
 		newText = text
@@ -1307,6 +1307,7 @@ func (u *User) handleMessageThreadContext(channelID, messageID, parentID, event,
 	case u.v.GetBool(u.br.Protocol()+".suffixcontext") && strings.HasSuffix(text, "\x01"):
 		suffix = " " + u.prefixContext(channelID, messageID, parentID, event)
 		newText = strings.Replace(text, " \x01", suffix+" \x01", 1)
+		maxlen = len(newText)
 	case u.v.GetBool(u.br.Protocol()+".suffixcontext") && u.v.GetBool(u.br.Protocol()+".showcontextmulti"):
 		suffix = " " + u.prefixContext(channelID, messageID, parentID, event)
 		newText = text


### PR DESCRIPTION
An action with less than the length of prefix gets split on multiple lines and causes "unknown CTCP ACTION".
```
|20:44 hloeung [hloeung@hloeung] requested unknown CTCP ACTION from #haw-test:
|20:44 <hloeung> [@@935mkzt8h3ggxmdsrqpyq45j3o]
|20:44 <hloeung> Testing A
```