### PR TITLE
Support for empty lines in syntax highlighted code blocks

### DIFF
--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -143,7 +143,7 @@ func (u *User) handleDirectMessageEvent(event *bridge.DirectMessageEvent) {
 	text = wordwrap.String(text, maxlen)
 	lines := strings.Split(text, "\n")
 	for _, text := range lines {
-		if text == "```" {
+		if strings.HasPrefix(text, "```") {
 			codeBlock = !codeBlock
 		}
 		// skip empty lines for anything not part of a code block.
@@ -287,7 +287,7 @@ func (u *User) handleChannelMessageEvent(event *bridge.ChannelMessageEvent) {
 	text = wordwrap.String(text, maxlen)
 	lines := strings.Split(text, "\n")
 	for _, text := range lines {
-		if text == "```" {
+		if strings.HasPrefix(text, "```") {
 			codeBlock = !codeBlock
 		}
 		// skip empty lines for anything not part of a code block.


### PR DESCRIPTION
That is:

```
Testing

` ` ` go
package main

import "fmt"

func main() {
    fmt.Println("Hello, 世界")
}
` ` `
Testing end

```

Becomes:

```
|14:24 <hloeung> [@@pwxztbmprbgim8hsa5j9147jao] Testing
|14:24 <hloeung> [@@pwxztbmprbgim8hsa5j9147jao] ``` go
|14:24 <hloeung> [@@pwxztbmprbgim8hsa5j9147jao] package main
|14:24 <hloeung> [@@pwxztbmprbgim8hsa5j9147jao]
|14:24 <hloeung> [@@pwxztbmprbgim8hsa5j9147jao] import "fmt"
|14:24 <hloeung> [@@pwxztbmprbgim8hsa5j9147jao]
|14:24 <hloeung> [@@pwxztbmprbgim8hsa5j9147jao] func main() {
|14:24 <hloeung> [@@pwxztbmprbgim8hsa5j9147jao]     fmt.Println("Hello, 世界")
|14:24 <hloeung> [@@pwxztbmprbgim8hsa5j9147jao] }
|14:24 <hloeung> [@@pwxztbmprbgim8hsa5j9147jao] ```
|14:24 <hloeung> [@@pwxztbmprbgim8hsa5j9147jao] Testing end
```

That is, empty lines are preserved in syntax formatted code blocks much like plain non-syntax highlighted code blocks.

Without this, it is shown as follows:

```
|14:15 <hloeung> [@@nn86pumhs3bexpjwb757cyr86r] ``` go
|14:15 <hloeung> [@@nn86pumhs3bexpjwb757cyr86r] package main
|14:15 <hloeung> [@@nn86pumhs3bexpjwb757cyr86r] import "fmt"
|14:15 <hloeung> [@@nn86pumhs3bexpjwb757cyr86r] func main() {
|14:15 <hloeung> [@@nn86pumhs3bexpjwb757cyr86r]     fmt.Println("Hello, 世界")
|14:15 <hloeung> [@@nn86pumhs3bexpjwb757cyr86r] }
|14:15 <hloeung> [@@nn86pumhs3bexpjwb757cyr86r] ```
```