### PR TITLE
Ignore when our user status is "offline"

### DIFF
--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -372,6 +372,9 @@ func (u *User) handleStatusChangeEvent(event *bridge.StatusChangeEvent) {
 		case "online":
 			logger.Debug("setting myself online")
 			u.Srv.EncodeMessage(u, irc.RPL_UNAWAY, []string{u.Nick}, "You are no longer marked as being away")
+		// Ignore `offline` status changes to prevent bouncing between being marked away and not.
+		case "offline":
+			logger.Debugf("doing nothing as status %s", event.Status)
 		default:
 			logger.Debug("setting myself away")
 			u.Srv.EncodeMessage(u, irc.RPL_NOWAWAY, []string{u.Nick}, "You have been marked as being away")


### PR DESCRIPTION
Otherwise, we end up bouncing between being marked away and not.

Mostly seems to happen when visiting via the web UI, at least that's how I used it to reproduce it.
```
|18:29 -!- You are no longer marked as being away
|18:32 -!- You have been marked as being away
|18:32 -!- You are no longer marked as being away
|18:32 -!- Irssi: No new messages in awaylog
|18:35 -!- You have been marked as being away
|18:35 -!- You are no longer marked as being away
|18:35 -!- Irssi: No new messages in awaylog
|18:37 -!- You have been marked as being away
|18:37 -!- You have been marked as being away
```

Then with additional debug logging, we can see the states:
```
ERRO[2022-11-14T18:29:45+11:00] HAW handleStatusChangeEvent(): online
ERRO[2022-11-14T18:29:45+11:00] HAW server status online
ERRO[2022-11-14T18:32:21+11:00] HAW handleStatusChangeEvent(): offline
ERRO[2022-11-14T18:32:21+11:00] HAW server status offline
ERRO[2022-11-14T18:32:47+11:00] HAW handleStatusChangeEvent(): online
ERRO[2022-11-14T18:32:47+11:00] HAW server status online
ERRO[2022-11-14T18:35:26+11:00] HAW handleStatusChangeEvent(): offline
ERRO[2022-11-14T18:35:26+11:00] HAW server status offline
ERRO[2022-11-14T18:37:23+11:00] HAW CmdAway called away                       module=matterircd
ERRO[2022-11-14T18:37:23+11:00] HAW SetStatus() called away
ERRO[2022-11-14T18:37:23+11:00] HAW handleStatusChangeEvent(): away
ERRO[2022-11-14T18:37:24+11:00] HAW server status away
```
(the last one being my setting `/away` via my IRC client)