### PR TITLE
Add support for tilde fenced code blocks

### DIFF
--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -138,15 +138,19 @@ func (u *User) handleDirectMessageEvent(event *bridge.DirectMessageEvent) {
 	}
 	text, prefix, suffix, showContext, maxlen := u.handleMessageThreadContext(prefixUser, event.MessageID, event.ParentID, event.Event, event.Text)
 
-	codeBlock := false
+	codeBlockBackTick := false
+	codeBlockTilde := false
 	text = wordwrap.String(text, maxlen)
 	lines := strings.Split(text, "\n")
 	for _, text := range lines {
-		if strings.HasPrefix(text, "```") {
-			codeBlock = !codeBlock
+		if strings.HasPrefix(text, "```") && !codeBlockTilde {
+			codeBlockBackTick = !codeBlockBackTick
+		}
+		if strings.HasPrefix(text, "~~~") && !codeBlockBackTick {
+			codeBlockTilde = !codeBlockTilde
 		}
 		// skip empty lines for anything not part of a code block.
-		if !codeBlock && text == "" {
+		if !codeBlockBackTick && !codeBlockTilde && text == "" {
 			continue
 		} else if text == "" {
 			text = " "
@@ -284,15 +288,19 @@ func (u *User) handleChannelMessageEvent(event *bridge.ChannelMessageEvent) {
 		text, prefix, suffix, showContext, maxlen = u.handleMessageThreadContext(event.ChannelID, event.MessageID, event.ParentID, event.Event, event.Text)
 	}
 
-	codeBlock := false
+	codeBlockBackTick := false
+	codeBlockTilde := false
 	text = wordwrap.String(text, maxlen)
 	lines := strings.Split(text, "\n")
 	for _, text := range lines {
-		if strings.HasPrefix(text, "```") {
-			codeBlock = !codeBlock
+		if strings.HasPrefix(text, "```") && !codeBlockTilde {
+			codeBlockBackTick = !codeBlockBackTick
+		}
+		if strings.HasPrefix(text, "~~~") && !codeBlockBackTick {
+			codeBlockTilde = !codeBlockTilde
 		}
 		// skip empty lines for anything not part of a code block.
-		if !codeBlock && text == "" {
+		if !codeBlockBackTick && !codeBlockTilde && text == "" {
 			continue
 		} else if text == "" {
 			text = " "


### PR DESCRIPTION
As pointed out by Furai on IRC, Mattermost supports tilde fenced code blocks so we should support it too, see https://www.markdownguide.org/extended-syntax/#fenced-code-blocks.