### PR TITLE
Ignore special channels

### DIFF
--- a/mm-go-irckit/server_commands.go
+++ b/mm-go-irckit/server_commands.go
@@ -115,6 +115,10 @@ func CmdJoin(s Server, u *User, msg *irc.Message) error {
 		// you can only join existing channels
 		var err error
 
+		if channelName == "&messages" || channelName == "&users" { //nolint:goconst
+			continue
+		}
+
 		channelID, topic, err := u.br.Join(channelName)
 		if err != nil {
 			logger.Errorf("Cannot join channel %s, id %s, err: %v", channelName, channelID, err)


### PR DESCRIPTION
This fixes and suppresses these error messages:
```
ERRO[2022-11-16T18:42:28Z] Cannot join channel &users, id , err: cannot join channel (+i)  module=matterircd
ERRO[2022-11-16T18:42:29Z] Cannot join channel &messages, id , err: cannot join channel (+i)  module=matterircd
```