### PR TITLE
Improve on logging and make consistent with matterclient

### DIFF
--- a/bridge/slack/utils.go
+++ b/bridge/slack/utils.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	logger "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/slack-go/slack"
 )
 
@@ -220,11 +220,11 @@ type httpClient struct {
 // taken from https://github.com/insomniacslk/irc-slack/blob/master/pkg/ircslack/irc_server.go
 func (hc httpClient) Do(req *http.Request) (*http.Response, error) {
 	if hc.cookie != "" {
-		logger.Debug("Setting auth cookie")
+		logrus.Debug("Setting auth cookie")
 		if strings.ToLower(req.URL.Scheme) == "https" {
 			req.Header.Add("Cookie", hc.cookie)
 		} else {
-			logger.Warning("Cookie is set but connection is not HTTPS, skipping")
+			logrus.Warning("Cookie is set but connection is not HTTPS, skipping")
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/42wim/matterircd/config"
 	irckit "github.com/42wim/matterircd/mm-go-irckit"
 	"github.com/google/gops/agent"
+	prefixed "github.com/matterbridge/logrus-prefixed-formatter"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -31,8 +32,11 @@ var (
 
 func main() {
 	ourlog := logrus.New()
-	ourlog.Formatter = &logrus.TextFormatter{FullTimestamp: true}
-	logger = ourlog.WithFields(logrus.Fields{"module": "matterircd"})
+	ourlog.Formatter = &prefixed.TextFormatter{
+		PrefixPadding: 11,
+		FullTimestamp: true,
+	}
+	logger = ourlog.WithFields(logrus.Fields{"prefix": "matterircd"})
 	config.Logger = logger
 
 	// config related. instantiate a new config.Config to store flags

--- a/mm-go-irckit/user.go
+++ b/mm-go-irckit/user.go
@@ -142,7 +142,7 @@ func (u *User) Encode(msgs ...*irc.Message) (err error) {
 			continue
 		}
 
-		logger.Debugf("-> %s", msg)
+		logger.Debugf("-> \"%s\"", msg)
 
 		err := u.Conn.Encode(msg)
 		if err != nil {
@@ -168,7 +168,7 @@ func (u *User) Decode() {
 	if bufferTimeout < 100 {
 		bufferTimeout = 100
 	}
-	logger.Debugf("using paste buffer timeout: %#v\n", bufferTimeout)
+	logger.Debugf("using paste buffer timeout: %#v", bufferTimeout)
 	t := timer.NewTimer(time.Duration(bufferTimeout) * time.Millisecond)
 	t.Stop()
 	go func(buffer chan *irc.Message, stop chan struct{}) {
@@ -204,7 +204,7 @@ func (u *User) Decode() {
 				if u.BufferedMsg != nil {
 					// trim last newline
 					u.BufferedMsg.Trailing = strings.TrimSpace(u.BufferedMsg.Trailing)
-					logger.Debugf("flushing buffer: %#v\n", u.BufferedMsg)
+					logger.Debugf("flushing buffer: %#v", u.BufferedMsg)
 					u.DecodeCh <- u.BufferedMsg
 					// clear buffer
 					u.BufferedMsg = nil
@@ -240,7 +240,7 @@ func (u *User) Decode() {
 		}
 		// PRIVMSG can be buffered
 		if msg.Command == "PRIVMSG" {
-			logger.Debugf("B: %#v\n", dmsg)
+			logger.Debugf("B: %#v", dmsg)
 			buffer <- msg
 		} else {
 			logger.Debug(dmsg)


### PR DESCRIPTION
I like to think it's an improvement.

Rather than append "module=matterircd" and such, have the module prefixed much like what's used by matterclient. Also split out what's logged by the main matterircd or the bridges (mattermost & slack).
```
[2022-11-19T22:19:20Z] DEBUG matterclient: found 162 channels for user in team ...
[2022-11-19T22:19:20Z] DEBUG matterclient: found 1333 public channels in team ...
[2022-11-19T22:19:20Z] DEBUG matterclient: WsClient: making connection: wss://myserver.mydomain.local
[2022-11-19T22:19:21Z] DEBUG matterclient: WsClient: connected
[2022-11-19T22:19:21Z] DEBUG matterclient: starting wsreceiver
[2022-11-19T22:19:21Z] DEBUG matterclient: executing OnWsConnect()
[2022-11-19T22:19:21Z] DEBUG matterircd: bridge not ready yet, sleeping
[2022-11-19T22:19:21Z]  INFO bridge/mattermost: login succeeded
...
[2022-11-19T22:32:16Z] DEBUG matterircd: in handleChannelMessageEvent
[2022-11-19T22:32:16Z] DEBUG bridge/mattermost: handleFileEvent() user hloeung sent 1 files
model.StringArray{"6qo5jidzg7y3uexwfuhkdg9wkw"}
[2022-11-19T22:32:16Z] DEBUG bridge/mattermost: handleWsActionPost() user hloeung sent
```