### PR TITLE
Remove unnecessary topic setting on channel join

### DIFF
--- a/mm-go-irckit/channel.go
+++ b/mm-go-irckit/channel.go
@@ -339,8 +339,6 @@ func (ch *channel) Join(u *User) error {
 		return nil
 	}
 
-	topic := ch.topic
-
 	ch.usersIdx[u.ID()] = u
 
 	ch.mu.Unlock()
@@ -373,20 +371,9 @@ func (ch *channel) Join(u *User) error {
 
 	ch.mu.RUnlock()
 
-	msgs := []*irc.Message{}
-
-	if topic != "" {
-		msgs = append(msgs, &irc.Message{
-			Prefix:   ch.Prefix(),
-			Command:  irc.RPL_TOPIC,
-			Params:   []string{u.Nick, ch.name},
-			Trailing: topic,
-		})
-	}
-
 	ch.SendNamesResponse(u)
 
-	return u.Encode(msgs...)
+	return nil
 }
 
 func (ch *channel) HasUser(u *User) bool {

--- a/mm-go-irckit/server_commands.go
+++ b/mm-go-irckit/server_commands.go
@@ -119,7 +119,7 @@ func CmdJoin(s Server, u *User, msg *irc.Message) error {
 			continue
 		}
 
-		channelID, topic, err := u.br.Join(channelName)
+		channelID, _, err := u.br.Join(channelName)
 		if err != nil {
 			logger.Errorf("Cannot join channel %s, id %s, err: %v", channelName, channelID, err)
 			s.EncodeMessage(u, irc.ERR_INVITEONLYCHAN, []string{u.Nick, channel}, "Cannot join channel (+i)")
@@ -143,10 +143,7 @@ func CmdJoin(s Server, u *User, msg *irc.Message) error {
 		}
 
 		ch := s.Channel(channelID)
-		ch.Topic(u, topic)
-
 		sync(channelID, channelName)
-
 		ch.Join(u)
 	}
 


### PR DESCRIPTION
Remove calls to set/update topics on joining and other users joining channels.

This causes the whole topic set by yourself in IRC for some channels.