### PR TITLE
Reduce calls to Mattermost server by caching replies

### DIFF
--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -400,13 +400,7 @@ func (u *User) handleReactionEvent(event interface{}) {
 
 	switch e := event.(type) {
 	case *bridge.ReactionAddEvent:
-		if !u.v.GetBool(u.br.Protocol() + ".hidereplies") {
-			nick := "(none)"
-			if e.ParentUser != nil {
-				nick = sanitizeNick(e.ParentUser.Nick)
-			}
-			message = fmt.Sprintf(" (re @%s: %s)", nick, e.Message)
-		}
+		message = e.Message
 		text = "added reaction: "
 		channelID = e.ChannelID
 		messageID = e.MessageID
@@ -414,13 +408,7 @@ func (u *User) handleReactionEvent(event interface{}) {
 		channelType = e.ChannelType
 		reaction = e.Reaction
 	case *bridge.ReactionRemoveEvent:
-		if !u.v.GetBool(u.br.Protocol() + ".hidereplies") {
-			nick := "(none)"
-			if e.ParentUser != nil {
-				nick = sanitizeNick(e.ParentUser.Nick)
-			}
-			message = fmt.Sprintf(" (re @%s: %s)", nick, e.Message)
-		}
+		message = e.Message
 		text = "removed reaction: "
 		channelID = e.ChannelID
 		messageID = e.MessageID
@@ -433,12 +421,6 @@ func (u *User) handleReactionEvent(event interface{}) {
 
 	if u.v.GetBool(u.br.Protocol() + ".hidereactions") {
 		logger.Debug("Not showing reaction: " + text + reaction)
-		return
-	}
-
-	// No need to show added/removed reaction messages for our own.
-	if sender.Me {
-		logger.Debug("Not showing own reaction: " + text + reaction)
 		return
 	}
 


### PR DESCRIPTION
Replaces https://github.com/42wim/matterircd/pull/508. For each message that's a reply to a thread, we make an extra API call to get the parent message to use as reply text. This caches that to reduce requests to the MM server.