### PR TITLE
Ensure colon present for empty messages per IRC protocol/spec

### DIFF
--- a/mm-go-irckit/channel.go
+++ b/mm-go-irckit/channel.go
@@ -132,10 +132,11 @@ func (ch *channel) Message(from *User, text string) {
 	lines := strings.Split(text, "\n")
 	for _, l := range lines {
 		msg := &irc.Message{
-			Prefix:   from.Prefix(),
-			Command:  irc.PRIVMSG,
-			Params:   []string{ch.name},
-			Trailing: l,
+			Prefix:        from.Prefix(),
+			Command:       irc.PRIVMSG,
+			Params:        []string{ch.name},
+			Trailing:      l,
+			EmptyTrailing: true,
 		}
 
 		ch.mu.RLock()
@@ -436,10 +437,11 @@ func (ch *channel) Spoof(from string, text string, cmd string, maxlen ...int) {
 	lines := strings.Split(text, "\n")
 	for _, l := range lines {
 		msg := &irc.Message{
-			Prefix:   &irc.Prefix{Name: from, User: from, Host: from},
-			Command:  cmd,
-			Params:   []string{ch.name},
-			Trailing: l,
+			Prefix:        &irc.Prefix{Name: from, User: from, Host: from},
+			Command:       cmd,
+			Params:        []string{ch.name},
+			Trailing:      l,
+			EmptyTrailing: true,
 		}
 
 		ch.mu.RLock()

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -762,10 +762,11 @@ func (u *User) addUserToChannelWorker(channels <-chan *bridge.ChannelInfo, throt
 
 func (u *User) MsgUser(toUser *User, msg string) {
 	u.Encode(&irc.Message{
-		Prefix:   toUser.Prefix(),
-		Command:  irc.PRIVMSG,
-		Params:   []string{u.Nick},
-		Trailing: msg,
+		Prefix:        toUser.Prefix(),
+		Command:       irc.PRIVMSG,
+		Params:        []string{u.Nick},
+		Trailing:      msg,
+		EmptyTrailing: true,
 	})
 }
 
@@ -783,9 +784,10 @@ func (u *User) MsgSpoofUser(sender *User, rcvuser string, msg string, maxlen ...
 				User: sender.Nick,
 				Host: sender.Host,
 			},
-			Command:  irc.PRIVMSG,
-			Params:   []string{rcvuser},
-			Trailing: l,
+			Command:       irc.PRIVMSG,
+			Params:        []string{rcvuser},
+			Trailing:      l,
+			EmptyTrailing: true,
 		})
 	}
 }


### PR DESCRIPTION
This fixes #[516](https://github.com/42wim/matterircd/issues/516) which was caused by the removal of new lines per commit 2ddb0d4.