### PR TITLE
Handle replies to posts part of threads

### DIFF
--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -276,10 +276,6 @@ func (m *Mattermost) MsgUser(userID, text string) (string, error) {
 }
 
 func (m *Mattermost) MsgUserThread(userID, parentID, text string) (string, error) {
-	props := make(map[string]interface{})
-
-	props["matterircd_"+m.mc.User.Id] = true
-
 	// create DM channel (only happens on first message)
 	dchannel, _, err := m.mc.Client.CreateDirectChannel(m.mc.User.Id, userID)
 	if err != nil {
@@ -288,20 +284,8 @@ func (m *Mattermost) MsgUserThread(userID, parentID, text string) (string, error
 
 	// build & send the message
 	text = strings.ReplaceAll(text, "\r", "")
-	post := &model.Post{
-		ChannelId: dchannel.Id,
-		Message:   text,
-		RootId:    parentID,
-	}
 
-	post.SetProps(props)
-
-	rp, _, err := m.mc.Client.CreatePost(post)
-	if err != nil {
-		return "", err
-	}
-
-	return rp.Id, nil
+	return m.MsgChannelThread(dchannel.Id, parentID, text)
 }
 
 func (m *Mattermost) MsgChannel(channelID, text string) (string, error) {
@@ -321,11 +305,34 @@ func (m *Mattermost) MsgChannelThread(channelID, parentID, text string) (string,
 	post.SetProps(props)
 
 	rp, _, err := m.mc.Client.CreatePost(post)
+	if err == nil {
+		return rp.Id, nil
+	}
+
+	if parentID == "" {
+		return "", err
+	}
+
+	// Try to work out if we're trying to reply to a post within a thread.
+	replyPost, _, err := m.mc.Client.GetPost(parentID, "")
 	if err != nil {
 		return "", err
 	}
 
-	return rp.Id, nil
+	post = &model.Post{
+		ChannelId: channelID,
+		Message:   text,
+		RootId:    replyPost.RootId,
+	}
+
+	post.SetProps(props)
+
+	rp, _, err = m.mc.Client.CreatePost(post)
+	if err == nil {
+		return rp.Id, nil
+	}
+
+	return "", err
 }
 
 func (m *Mattermost) ModifyPost(msgID, text string) error {


### PR DESCRIPTION
When replies are accidentally using the post IDs for those part of threads or reactions, we end up with an error:
```
msg: ... could not be sent : Invalid RootId parameter.,
```

This better handles that by trying to get the post and following the parent/root ID of that.

So given the following:

```
|23:52 <wuser1> my reply message (re @suser2: my parent message …)
[@@hfe4hxb13pr59xf6fs5qfdrquh,gw4zu7kmji8r3byk4qer1dx7xa]
```

One can reply with either the msg thread/parent/root ID of `@@hfe4hxb13pr59xf6fs5qfdrquh` or using the actual post ID, `@@gw4zu7kmji8r3byk4qer1dx7xa`.

It's also useful for reactions too which we're only showing the post ID (will work on a separate PR to show the thread/parent/root ID for reactions too).