### PR TITLE
Evict cached msg on edit/delete to ensure replies don't use stale/old msgs

### DIFF
--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -956,6 +956,9 @@ func (m *Mattermost) handleWsActionPost(rmsg *model.WebSocketEvent) {
 			channelType = "D"
 		}
 		dmchannel = name
+
+		// We need to remove it from the cache so that replies use the latest msg.
+		m.msgParentCache.Remove(data.Id)
 	}
 
 	for _, msg := range msgs {


### PR DESCRIPTION
Testing:

```
|17:33 <hloeung> Testing (re @hloeung: Testing my edited message …) [↪1hfz…,xbku…]
|17:33 <hloeung> Test message (edited) [1hfz…]
|17:34 <hloeung> Testing (re @hloeung: Test message) [↪1hfz…,f676…]
|17:34 <hloeung> Testing, reply (re @hloeung: Test message) [↪1hfz…,yegh…]
|17:34 <hloeung> Testing, updated message (edited) [1hfz…]
|17:34 <hloeung> Testing, reply after parent updated (re @hloeung: Testing, updated message …) [↪1hfz…,1soj…]
```

Without it, if the original/parent message has been edited/updated, all replies will show the old message.