### PR TITLE
Allow ignoring Mattermost server version when checking if supported

### DIFF
--- a/matterircd.toml.example
+++ b/matterircd.toml.example
@@ -53,6 +53,9 @@ PasteBufferTimeout = 2500
 #use http connection to mattermost (default false)
 Insecure = false
 
+#ignore the Mattermost server version when checking if supported
+#ignoreserverversion = false
+
 #an array of channels that only will be joined on IRC. JoinExlude and JoinInclude will not be checked
 #regexp is supported
 #If it's empty, it means all channels get joined (except those defined in JoinExclude)

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -869,7 +869,7 @@ func (u *User) loginTo(protocol string) error {
 		u.br, err = slack.New(u.v, u.Credentials, u.eventChan, u.addUsersToChannels)
 	case "mattermost":
 		u.eventChan = make(chan *bridge.Event)
-		if strings.HasPrefix(u.getMattermostVersion(), "7.") || strings.HasPrefix(u.getMattermostVersion(), "8.") {
+		if u.v.GetBool("mattermost.ignoreserverversion") || strings.HasPrefix(u.getMattermostVersion(), "7.") || strings.HasPrefix(u.getMattermostVersion(), "8.") {
 			u.br, _, err = mattermost.New(u.v, u.Credentials, u.eventChan, u.addUsersToChannels)
 		} else {
 			return fmt.Errorf("mattermost version %s not supported", u.getMattermostVersion())


### PR DESCRIPTION
This makes it a little bit more future proof by allowing the admin/user to select ignore supported Mattermost server version and **use at own risk** per https://github.com/42wim/matterircd/issues/537