### PR TITLE
Fix incorrect msg/thread counters

### DIFF
--- a/mm-go-irckit/server_commands.go
+++ b/mm-go-irckit/server_commands.go
@@ -478,16 +478,11 @@ func parseReactionToMsg(u *User, msg *irc.Message, channelID string) bool {
 			logger.Errorf("couldn't parseint %s: %s", msgID, err)
 		}
 
-		u.msgMapMutex.RLock()
-		defer u.msgMapMutex.RUnlock()
+		u.msgMapIndexMutex.RLock()
+		defer u.msgMapIndexMutex.RUnlock()
 
-		m := u.msgMap[channelID]
-
-		for k, v := range m {
-			if v == int(id) {
-				msgID = k
-				break
-			}
+		if _, ok := u.msgMapIndex[channelID][int(id)]; ok {
+			msgID = u.msgMapIndex[channelID][int(id)]
 		}
 	}
 
@@ -549,17 +544,11 @@ func parseModifyMsg(u *User, msg *irc.Message, channelID string) bool {
 			logger.Errorf("couldn't parseint %s: %s", matches[1], err)
 		}
 
-		u.msgMapMutex.RLock()
-		defer u.msgMapMutex.RUnlock()
+		u.msgMapIndexMutex.RLock()
+		defer u.msgMapIndexMutex.RUnlock()
 
-		m := u.msgMap[channelID]
-
-		for k, v := range m {
-			if v != int(id) {
-				continue
-			}
-
-			msgID = k
+		if _, ok := u.msgMapIndex[channelID][int(id)]; ok {
+			msgID = u.msgMapIndex[channelID][int(id)]
 
 			u.msgLastMutex.Lock()
 			defer u.msgLastMutex.Unlock()
@@ -619,15 +608,11 @@ func parseThreadID(u *User, msg *irc.Message, channelID string) (string, string)
 			return "", ""
 		}
 
-		u.msgMapMutex.RLock()
-		defer u.msgMapMutex.RUnlock()
+		u.msgMapIndexMutex.RLock()
+		defer u.msgMapIndexMutex.RUnlock()
 
-		m := u.msgMap[channelID]
-
-		for k, v := range m {
-			if v == int(id) {
-				return k, matches[2]
-			}
+		if _, ok := u.msgMapIndex[channelID][int(id)]; ok {
+			return u.msgMapIndex[channelID][int(id)], matches[2]
 		}
 	case len(matches[1]) == 26:
 		return matches[1], matches[2]


### PR DESCRIPTION
When using mattericd's default threading, the msgMap is populated with message/thread IDs and never removed. This means that when we cycle past 4k, we can have entries with duplicate counters causing issues where replies could end up to an incorrect thread.

This fixes it by introducing an index with the counter and to which message/thread ID. When index entries are updated and the thread no longer referenced, the entries in the msgMap are removed.

This also ensures that msgMap remains a constant bounded size.

It should be noted that this also relies on https://github.com/42wim/matterircd/pull/544, in particular https://github.com/42wim/matterircd/blob/master/mm-go-irckit/server_commands.go#L665