### PR TITLE
Allow disabling specific chat services / protocols

### DIFF
--- a/matterircd.toml.example
+++ b/matterircd.toml.example
@@ -50,6 +50,9 @@ PasteBufferTimeout = 2500
 #
 #DefaultTeam = "mycompany"
 
+#disable Mattermost support
+#Disable = false
+
 #use http connection to mattermost (default false)
 Insecure = false
 
@@ -169,6 +172,9 @@ LastViewedSaveFile = "matterircd-lastsaved.db"
 ##### SLACK EXAMPLE #########
 #############################
 [slack]
+#disable Slack support
+#Disable = false
+
 #deny specific users from connecting.
 #As we only connect using tokens, this will first do a ccnnection to see what username the token is from. If this
 #username is on the DenyUsers the user will be disconnected.
@@ -230,6 +236,9 @@ PrefixContext = false
 ##### MASTODON EXAMPLE ######
 #############################
 [mastodon]
+#disable Mastodon support
+#Disable = false
+
 #Go to https://yourmastodonserver/settings/applications/new
 #Use matterircd as application name (default read/write/follow scopes are ok)
 #Click on submit

--- a/mm-go-irckit/service.go
+++ b/mm-go-irckit/service.go
@@ -41,6 +41,11 @@ func login(u *User, toUser *User, args []string, service string) {
 	}
 
 	if service == "mastodon" {
+		if u.v.GetBool("mastodon.disable") {
+			logger.Info("Mastodon disabled")
+			return
+		}
+
 		fmt.Println("login mastodon")
 		err := u.loginTo("mastodon")
 		if err != nil {
@@ -54,6 +59,11 @@ func login(u *User, toUser *User, args []string, service string) {
 	}
 
 	if service == "slack" {
+		if u.v.GetBool("slack.disable") {
+			logger.Info("Slack disabled")
+			return
+		}
+
 		var err error
 
 		if len(args) != 1 && len(args) != 3 {
@@ -109,6 +119,11 @@ func login(u *User, toUser *User, args []string, service string) {
 			u.MsgUser(toUser, "token used: "+u.Credentials.Token)
 		}
 
+		return
+	}
+
+	if u.v.GetBool("mattermost.disable") {
+		logger.Info("Mattermost disabled")
 		return
 	}
 


### PR DESCRIPTION
Certain things like Slack runs various things on startup and connect even though a user may not use it (e.g. myself).

This adds support for disabling specific chat services / protocols completely.