### PR TITLE
Add missing event to prefixContext() calls for easier debugging

### DIFF
--- a/mm-go-irckit/server_commands.go
+++ b/mm-go-irckit/server_commands.go
@@ -402,7 +402,7 @@ func CmdPrivMsg(s Server, u *User, msg *irc.Message) error {
 		u.saveLastViewedAt(ch.ID())
 
 		if u.v.GetBool(u.br.Protocol()+".prefixcontext") || u.v.GetBool(u.br.Protocol()+".suffixcontext") {
-			u.prefixContext(ch.ID(), msgID, "", "")
+			u.prefixContext(ch.ID(), msgID, "", "posted_self")
 		}
 
 		return nil
@@ -447,7 +447,7 @@ func CmdPrivMsg(s Server, u *User, msg *irc.Message) error {
 			u.saveLastViewedAt(toUser.User)
 
 			if u.v.GetBool(u.br.Protocol()+".prefixcontext") || u.v.GetBool(u.br.Protocol()+".suffixcontext") {
-				u.prefixContext(toUser.User, msgID, "", "")
+				u.prefixContext(toUser.User, msgID, "", "posted_self")
 			}
 
 		default:
@@ -662,7 +662,7 @@ func threadMsgChannelUser(u *User, msg *irc.Message, channelID string, toUser bo
 	u.saveLastViewedAt(channelID)
 
 	if u.v.GetBool(u.br.Protocol()+".prefixcontext") || u.v.GetBool(u.br.Protocol()+".suffixcontext") {
-		u.prefixContext(channelID, msgID, "", "")
+		u.prefixContext(channelID, msgID, threadID, "posted_self")
 	}
 
 	return true

--- a/mm-go-irckit/service.go
+++ b/mm-go-irckit/service.go
@@ -341,14 +341,14 @@ func scrollback(u *User, toUser *User, args []string, service string) {
 		for _, post := range strings.Split(p.Message, "\n") {
 			switch { // nolint:dupl
 			case (u.v.GetString(u.br.Protocol()+".threadcontext") == "mattermost" || u.v.GetString(u.br.Protocol()+".threadcontext") == "mattermost+post") && strings.HasPrefix(args[0], "#") && nick != "system":
-				threadMsgID := u.prefixContext("", p.Id, p.RootId, "")
+				threadMsgID := u.prefixContext("", p.Id, p.RootId, "scrollback")
 				scrollbackMsg := u.formatContextMessage(ts.Format("2006-01-02 15:04"), threadMsgID, post)
 				spoof(nick, scrollbackMsg)
 			case strings.HasPrefix(args[0], "#"):
 				scrollbackMsg := "[" + ts.Format("2006-01-02 15:04") + "] " + post
 				spoof(nick, scrollbackMsg)
 			case u.v.GetString(u.br.Protocol()+".threadcontext") == "mattermost" || u.v.GetString(u.br.Protocol()+".threadcontext") == "mattermost+post":
-				threadMsgID := u.prefixContext("", p.Id, p.RootId, "")
+				threadMsgID := u.prefixContext("", p.Id, p.RootId, "scrollback")
 				scrollbackMsg := u.formatContextMessage(ts.Format("2006-01-02 15:04"), threadMsgID, post)
 				u.MsgSpoofUser(scrollbackUser, nick, scrollbackMsg)
 			default:
@@ -365,11 +365,11 @@ func scrollback(u *User, toUser *User, args []string, service string) {
 			fileMsg := "download file - " + fname
 			switch { // nolint:dupl
 			case (u.v.GetString(u.br.Protocol()+".threadcontext") == "mattermost" || u.v.GetString(u.br.Protocol()+".threadcontext") == "mattermost+post") && strings.HasPrefix(args[0], "#"):
-				threadMsgID := u.prefixContext("", p.Id, p.RootId, "")
+				threadMsgID := u.prefixContext("", p.Id, p.RootId, "scrollback_file")
 				scrollbackMsg := u.formatContextMessage(ts.Format("2006-01-02 15:04"), threadMsgID, fileMsg)
 				spoof(nick, scrollbackMsg)
 			case u.v.GetString(u.br.Protocol()+".threadcontext") == "mattermost" || u.v.GetString(u.br.Protocol()+".threadcontext") == "mattermost+post":
-				threadMsgID := u.prefixContext("", p.Id, p.RootId, "")
+				threadMsgID := u.prefixContext("", p.Id, p.RootId, "scrollback_file")
 				scrollbackMsg := u.formatContextMessage(ts.Format("2006-01-02 15:04"), threadMsgID, fileMsg)
 				u.MsgSpoofUser(scrollbackUser, nick, scrollbackMsg)
 			case strings.HasPrefix(args[0], "#"):

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -323,7 +323,7 @@ func (u *User) handleFileEvent(event *bridge.FileEvent) {
 	for _, fname := range event.Files {
 		fileMsg := "download file - " + fname.Name
 		if u.v.GetString(u.br.Protocol()+".threadcontext") == "mattermost" || u.v.GetString(u.br.Protocol()+".threadcontext") == "mattermost+post" {
-			threadMsgID := u.prefixContext(event.ChannelID, event.MessageID, event.ParentID, "")
+			threadMsgID := u.prefixContext(event.ChannelID, event.MessageID, event.ParentID, "posted_file")
 			fileMsg = u.formatContextMessage("", threadMsgID, fileMsg)
 		}
 
@@ -716,7 +716,7 @@ func (u *User) addUserToChannelWorker(channels <-chan *bridge.ChannelInfo, throt
 
 				replayMsg := fmt.Sprintf("[%s] %s", ts.Format("15:04"), post)
 				if (u.v.GetBool(u.br.Protocol()+".prefixcontext") || u.v.GetBool(u.br.Protocol()+".suffixcontext")) && (u.v.GetString(u.br.Protocol()+".threadcontext") == "mattermost" || u.v.GetString(u.br.Protocol()+".threadcontext") == "mattermost+post") && nick != systemUser {
-					threadMsgID := u.prefixContext("", p.Id, p.RootId, "")
+					threadMsgID := u.prefixContext("", p.Id, p.RootId, "replay")
 					replayMsg = u.formatContextMessage(ts.Format("15:04"), threadMsgID, post)
 				}
 				spoof(nick, replayMsg)
@@ -729,7 +729,7 @@ func (u *User) addUserToChannelWorker(channels <-chan *bridge.ChannelInfo, throt
 			for _, fname := range u.br.GetFileLinks(p.FileIds) {
 				fileMsg := "download file - " + fname
 				if u.v.GetString(u.br.Protocol()+".threadcontext") == "mattermost" || u.v.GetString(u.br.Protocol()+".threadcontext") == "mattermost+post" {
-					threadMsgID := u.prefixContext("", p.Id, p.RootId, "")
+					threadMsgID := u.prefixContext("", p.Id, p.RootId, "replay_file")
 					fileMsg = u.formatContextMessage(ts.Format("15:04"), threadMsgID, fileMsg)
 				}
 				spoof(nick, fileMsg)


### PR DESCRIPTION
That way, we can tell where prefixContext() is being called from