### PR TITLE
Convert Mattermost markdown formatting / emphasis to IRC

### DIFF
--- a/matterircd.toml.example
+++ b/matterircd.toml.example
@@ -153,6 +153,9 @@ ShowMentions = false
 # This disables that making them appear as normal PRIVMSGs.
 #DisableDefaultMentions = true
 
+# Disable formatting / emphasis of text from Mattermost markdown to IRC (bold & italics)
+#DisableIRCEmphasis = true
+
 # Enable syntax highlighting for code blocks.
 # Formatter and Style are passed through to the chroma v2 package.
 #   https://github.com/alecthomas/chroma/blob/master/formatters/tty_indexed.go#L262

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -1197,12 +1197,6 @@ var (
 	italicsEndRegExp   = regexp.MustCompile(`(\S)(?:_)([\s$]*)`)
 )
 
-// Monospace 0x11  `    (`text`)
-var (
-	monospaceStartRegExp = regexp.MustCompile(`([\s^]*)(?:\x60{1})(\S)`)
-	monospaceEndRegExp   = regexp.MustCompile(`(\S)(?:\x60{1})([\s$]*)`)
-)
-
 func markdown2irc(msg string) string {
 	// Bold      0x02  **   (**text**)
 	msg = boldStartRegExp.ReplaceAllString(msg, "$1\x02$2")
@@ -1211,10 +1205,6 @@ func markdown2irc(msg string) string {
 	// Italics   0x1D  _    (_text_)
 	msg = italicsStartRegExp.ReplaceAllString(msg, "$1\x1d$2")
 	msg = italicsEndRegExp.ReplaceAllString(msg, "$1\x1d$2")
-
-	// Monospace 0x11  `    (`text`)
-	msg = monospaceStartRegExp.ReplaceAllString(msg, "$1\x11$2")
-	msg = monospaceEndRegExp.ReplaceAllString(msg, "$1\x11$2")
 
 	return msg
 }

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -161,7 +161,7 @@ func (u *User) handleDirectMessageEvent(event *bridge.DirectMessageEvent) {
 			continue
 		}
 
-		if !codeBlockBackTick && !codeBlockTilde {
+		if !u.v.GetBool(u.br.Protocol()+".disableircemphasis") && !codeBlockBackTick && !codeBlockTilde {
 			text = markdown2irc(text)
 		}
 
@@ -311,7 +311,7 @@ func (u *User) handleChannelMessageEvent(event *bridge.ChannelMessageEvent) {
 			continue
 		}
 
-		if !codeBlockBackTick && !codeBlockTilde {
+		if !u.v.GetBool(u.br.Protocol()+".disableircemphasis") && !codeBlockBackTick && !codeBlockTilde {
 			text = markdown2irc(text)
 		}
 

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -1188,21 +1188,21 @@ func (u *User) formatCodeBlockText(text string, prefix string, codeBlockBackTick
 // Bold & Italic - https://www.markdownguide.org/basic-syntax#bold-and-italic
 var boldItalicRegExp = []*regexp.Regexp{
 	regexp.MustCompile(`(?:\*\*\*)+?(.+?)(?:\*\*\*)+?`),
-	regexp.MustCompile(`(?:\_\_\_)+?(.+?)(?:\_\_\_)+?`),
-	regexp.MustCompile(`(?:\_\_\*)+?(.+?)(?:\*\_\_)+?`),
-	regexp.MustCompile(`(?:\*\*\_)+?(.+?)(?:\_\*\*)+?`),
+	regexp.MustCompile(`\b(?:\_\_\_)+?(.+?)(?:\_\_\_)+?\b`),
+	regexp.MustCompile(`\b(?:\_\_\*)+?(.+?)(?:\*\_\_)+?\b`),
+	regexp.MustCompile(`\b(?:\*\*\_)+?(.+?)(?:\_\*\*)+?\b`),
 }
 
 // Bold - https://www.markdownguide.org/basic-syntax#bold
 var boldRegExp = []*regexp.Regexp{
 	regexp.MustCompile(`(?:\*\*)+?(.+?)(?:\*\*)+?`),
-	regexp.MustCompile(`(?:\_\_)+?(.+?)(?:\_\_)+?`),
+	regexp.MustCompile(`\b(?:\_\_)+?(.+?)(?:\_\_)+?\b`),
 }
 
 // Italic - https://www.markdownguide.org/basic-syntax#italic
 var italicRegExp = []*regexp.Regexp{
-	regexp.MustCompile(`(?:\*)+?(.+?)(?:\*)+?`),
-	regexp.MustCompile(`(?:\_)+?(.+?)(?:\_)+?`),
+	regexp.MustCompile(`(?:\*)+?([^\*]+?)(?:\*)+?`),
+	regexp.MustCompile(`\b(?:\_)+?([^_]+?)(?:\_)+?\b`),
 }
 
 func markdown2irc(msg string) string {


### PR DESCRIPTION
Do the reverse of https://github.com/42wim/matterircd/pull/546 for https://github.com/42wim/matterircd/issues/258, convert Mattermost posts with markdown formatting / emphasis to IRC. Example:

    Testing **Bold** Testing **_Bold+Italics_** Testing _Italics_ Testing `monospace` Testing

Becomes:

![N8de65oriH](https://github.com/42wim/matterircd/assets/95021/60060f1f-a46d-48d8-a3a7-b74b47d9200f)
(FWIW, monospace support was added in irssi 1.4.4, I'm running 1.4.3 and why it's showing as `Q`)