### PR TITLE
Fix mentions for every message

### DIFF
--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -135,6 +135,10 @@ func (u *User) handleDirectMessageEvent(event *bridge.DirectMessageEvent) {
 				continue
 			}
 
+			if m == "" {
+				continue
+			}
+
 			if strings.Contains(event.Text, m) {
 				event.Text = event.Text + " (mention " + u.Nick + ")"
 			}
@@ -279,6 +283,10 @@ func (u *User) handleChannelMessageEvent(event *bridge.ChannelMessageEvent) {
 	if u.v.GetBool(u.br.Protocol() + ".showmentions") {
 		for _, m := range u.MentionKeys {
 			if m == u.Nick {
+				continue
+			}
+
+			if m == "" {
 				continue
 			}
 


### PR DESCRIPTION
This fixes https://github.com/42wim/matterircd/issues/561

If NotifyProps["mention_keys"] (aka "Words That Trigger Mentions") is empty, `strings.Split(mentionkeys, ",")` creates a slice with one element, the empty string - `[]string{""}` rather than an empty slice (`[]string{}`). This causes all lines to match.

We can handle it at the `strings.Split()`, or around it. But I thought best to handle it in the loop in case the user does something like `test1,test2,,test3` where there is an accidental comma.