### PR TITLE
Fix join and part/leave on replay

### DIFF
--- a/mm-go-irckit/channel.go
+++ b/mm-go-irckit/channel.go
@@ -162,14 +162,17 @@ func (ch *channel) Part(u *User, text string) {
 
 	if _, ok := ch.usersIdx[u.ID()]; !ok {
 		ch.mu.Unlock()
-
+		for _, to := range ch.usersIdx {
+			if !to.Ghost {
+				to.Encode(msg) //nolint:errcheck
+			}
+		}
 		u.Encode(&irc.Message{
 			Prefix:   ch.Prefix(),
 			Command:  irc.ERR_NOTONCHANNEL,
 			Params:   []string{ch.name},
-			Trailing: "You're not on that channel",
+			Trailing: "User not on that channel",
 		})
-
 		return
 	}
 
@@ -335,8 +338,20 @@ func (ch *channel) Join(u *User) error {
 		return nil
 	}
 
+	msg := &irc.Message{
+		Prefix:  u.Prefix(),
+		Command: irc.JOIN,
+		Params:  []string{ch.name},
+	}
+
 	if _, exists := ch.usersIdx[u.ID()]; exists {
 		ch.mu.Unlock()
+		for _, to := range ch.usersIdx {
+			// only send join messages to real users
+			if !to.Ghost {
+				to.Encode(msg) //nolint:errcheck
+			}
+		}
 		return nil
 	}
 
@@ -352,12 +367,6 @@ func (ch *channel) Join(u *User) error {
 	// speed up &users join
 	if ch.name == "&users" && u.Ghost {
 		return nil
-	}
-
-	msg := &irc.Message{
-		Prefix:  u.Prefix(),
-		Command: irc.JOIN,
-		Params:  []string{ch.name},
 	}
 
 	// send regular users a notification of the join

--- a/mm-go-irckit/channel.go
+++ b/mm-go-irckit/channel.go
@@ -163,7 +163,7 @@ func (ch *channel) Part(u *User, text string) {
 	if _, ok := ch.usersIdx[u.ID()]; !ok {
 		ch.mu.Unlock()
 		for _, to := range ch.usersIdx {
-			if !to.Ghost {
+			if !to.Ghost && to.Nick != u.Nick {
 				to.Encode(msg) //nolint:errcheck
 			}
 		}
@@ -348,7 +348,7 @@ func (ch *channel) Join(u *User) error {
 		ch.mu.Unlock()
 		for _, to := range ch.usersIdx {
 			// only send join messages to real users
-			if !to.Ghost {
+			if !to.Ghost && to.Nick != u.Nick {
 				to.Encode(msg) //nolint:errcheck
 			}
 		}

--- a/mm-go-irckit/channel.go
+++ b/mm-go-irckit/channel.go
@@ -167,7 +167,7 @@ func (ch *channel) Part(u *User, text string) {
 			Prefix:   ch.Prefix(),
 			Command:  irc.ERR_NOTONCHANNEL,
 			Params:   []string{ch.name},
-			Trailing: "User not on that channel",
+			Trailing: "You're not on that channel",
 		})
 
 		return


### PR DESCRIPTION
Without this, on matterircd reconnect & relay, users in channels can be out of sync. This causes issues with trying to auto-complete IRC nicks for example.