### PR TITLE
Fix channels created for file events via DM

### DIFF
--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -347,9 +347,9 @@ func (u *User) handleChannelMessageEvent(event *bridge.ChannelMessageEvent) {
 }
 
 func (u *User) handleFileEvent(event *bridge.FileEvent) {
-	ch := u.getMessageChannel(event.ChannelID, event.Sender)
-	if event.ChannelType != "D" && ch.ID() == "&messages" {
-		if u.v.GetBool(u.br.Protocol() + ".showonlyjoined") {
+	if u.v.GetBool(u.br.Protocol()+".showonlyjoined") && event.ChannelType != "D" {
+		ch := u.getMessageChannel(event.ChannelID, event.Sender)
+		if ch.ID() == "&messages" {
 			return
 		}
 	}


### PR DESCRIPTION
We only call getMessageChannel() when .showonlyjoined and it's not a direct message. getMessageChannel() creates a channel in IRC.

Fixes #571