### PR TITLE
Add support for DM header updates, as topics

### DIFF
--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -927,7 +927,6 @@ func (m *Mattermost) handleWsActionPost(rmsg *model.WebSocketEvent) {
 		}
 		topic := extraProps["new_header"].(string)
 
-		// DirectMessage
 		if channelType == "D" {
 			event := &bridge.Event{
 				Type: "direct_message",

--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -1006,7 +1006,6 @@ func (m *Mattermost) handleWsActionPost(rmsg *model.WebSocketEvent) {
 
 	for _, msg := range msgs {
 		switch {
-		// DirectMessage
 		case channelType == "D":
 			event := &bridge.Event{
 				Type: "direct_message",

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -145,11 +145,23 @@ func (u *User) handleDirectMessageEvent(event *bridge.DirectMessageEvent) {
 		}
 	}
 
-	prefixUser := event.Sender.User
-	if event.Sender.Me {
-		prefixUser = event.Receiver.User
+	var text string
+	var showContext bool
+	var maxlen int
+
+	prefix := ""
+	suffix := ""
+	if event.Event == "dm_topic" {
+		text = event.Text
+		showContext = false
+		maxlen = 0
+	} else {
+		prefixUser := event.Sender.User
+		if event.Sender.Me {
+			prefixUser = event.Receiver.User
+		}
+		text, prefix, suffix, showContext, maxlen = u.handleMessageThreadContext(prefixUser, event.MessageID, event.ParentID, event.Event, event.Text)
 	}
-	text, prefix, suffix, showContext, maxlen := u.handleMessageThreadContext(prefixUser, event.MessageID, event.ParentID, event.Event, event.Text)
 
 	lexer := ""
 	codeBlockBackTick := false


### PR DESCRIPTION
In Mattermost, users can change / update the "Conversation Header" (or channel header / topic). This updates matterircd to show these as IRC actions.