### PR TITLE
Bump max. line length

### DIFF
--- a/vendor/github.com/sorcix/irc/message.go
+++ b/vendor/github.com/sorcix/irc/message.go
@@ -16,7 +16,7 @@ const (
 	prefixHost byte = 0x40 // Hostname
 	space      byte = 0x20 // Separator
 
-	maxLength = 510 // Maximum length is 512 - 2 for the line endings.
+	maxLength = 8190 // Maximum length is 8192 - 2 for the line endings.
 )
 
 func cutsetFunc(r rune) bool {


### PR DESCRIPTION
Mattermost, and probably the others, allows for a longer max. line. In particular, topics (other messages are already using wordwrap).

Unfortunately, the upstream project, https://github.com/sorcix/irc, has been archived since Feb 21, 2023 and is currently in "read-only" mode.