### PR TITLE
Show own post when edited or deleted

### DIFF
--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -751,6 +751,11 @@ func (m *Mattermost) wsActionPostSkip(rmsg *model.WebSocketEvent) bool {
 		return true
 	}
 
+	// Show own edited / deleted
+	if rmsg.EventType() == model.WebsocketEventPostEdited || rmsg.EventType() == model.WebsocketEventPostDeleted {
+		return false
+	}
+
 	msgID := data.Id
 	msg := data.Message
 	channel := m.GetChannelName(data.ChannelId)

--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -752,7 +752,7 @@ func (m *Mattermost) wsActionPostSkip(rmsg *model.WebSocketEvent) bool {
 	}
 
 	// Show own edited / deleted
-	if rmsg.EventType() == model.WebsocketEventPostEdited || rmsg.EventType() == model.WebsocketEventPostDeleted {
+	if !m.v.GetBool("disableshowownmodified") && (rmsg.EventType() == model.WebsocketEventPostEdited || rmsg.EventType() == model.WebsocketEventPostDeleted) {
 		return false
 	}
 

--- a/matterircd.toml.example
+++ b/matterircd.toml.example
@@ -167,6 +167,9 @@ ShowMentions = false
 # Disable formatting / emphasis of text from Mattermost markdown to IRC (bold & italics)
 #DisableIRCEmphasis = true
 
+# Disable showing own edited or deleted posts from mattermost
+#DisableShowOwnModified = true
+
 # Enable syntax highlighting for code blocks.
 # Formatter and Style are passed through to the chroma v2 package.
 #   https://github.com/alecthomas/chroma/blob/master/formatters/tty_indexed.go#L262


### PR DESCRIPTION
Fixes https://github.com/42wim/matterircd/issues/590

```
|09:22 <hloeung> Test
|09:23 <hloeung> s//
|09:23 <hloeung> [q6shb…] Test (deleted)
```

```
|09:23 <hloeung> Test again
|09:23 <hloeung> s//edit last message/
|09:23 <hloeung> [6589y…] edit last message/ (edited)
```