### PR TITLE
Add support for ANSI escape for code block line prefixes for formatting and colors

### DIFF
--- a/matterircd.toml.example
+++ b/matterircd.toml.example
@@ -177,7 +177,7 @@ ShowMentions = false
 #   https://github.com/alecthomas/chroma/tree/master/styles
 # These are different colour schemes/styles. E.g. pygments, emacs, autumn, etc.
 SyntaxHighlighting = "terminal256:pygments"
-CodeBlockPrefix = ""
+CodeBlockPrefix = "\\x1b[1;38;2;0;82;204m|\\x1b[0m "
 
 # Path to file to store last viewed information. This is useful for replying only
 # the messages missed.

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -1218,6 +1219,12 @@ func (u *User) formatCodeBlockText(text string, prefix string, codeBlockBackTick
 
 	syntaxHighlighting := u.v.GetString(u.br.Protocol() + ".syntaxhighlighting")
 	linePrefix := u.v.GetString(u.br.Protocol() + ".codeblockprefix")
+	if linePrefix != "" {
+		unq, err := strconv.Unquote(`"` + linePrefix + `"`)
+		if err == nil {
+			linePrefix = unq
+		}
+	}
 
 	if (strings.HasPrefix(text, "```") || strings.HasPrefix(text, prefix+"```")) && !codeBlockTilde {
 		codeBlockBackTick = !codeBlockBackTick


### PR DESCRIPTION
Following on https://github.com/42wim/matterircd/pull/606

So we could have something like `CodeBlockPrefix = "\\x1b[1;38;2;0;82;204m|\\x1b[0m "` and it'll add colors to prefixes used for code blocks.