### PR TITLE
Fix Mattermost system_generic messages to be from the 'system' user

### DIFF
--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -991,7 +991,7 @@ func (m *Mattermost) handleWsActionPost(rmsg *model.WebSocketEvent) {
 		return
 	}
 
-	if data.Type == model.PostTypeAddToTeam || data.Type == model.PostTypeRemoveFromTeam {
+	if data.Type == model.PostTypeSystemGeneric || data.Type == model.PostTypeAddToTeam || data.Type == model.PostTypeRemoveFromTeam {
 		ghost = &bridge.UserInfo{
 			Nick: "system",
 		}


### PR DESCRIPTION
e.g. System messages with:

```
\"message\":\"userX was deactivated. They managed the following bot accounts which are still enabled....\", \"type\":\"system_generic\"
```