### PR TITLE
Use non-breaking space for message attachment formatting so prefixes stay together with content

### DIFF
--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -1561,7 +1561,7 @@ func parseMatterpollToMsg(attachments []*model.SlackAttachment, unicode bool) st
 		prefixChar = "┃"
 	}
 	for _, attachment := range attachments {
-		prefix := "\033[1;38;2;0;82;204m" + prefixChar + "\033[0m "
+		prefix := "\033[1;38;2;0;82;204m" + prefixChar + "\033[0m "
 
 		if attachment.AuthorName != "" {
 			msg += prefix + "@" + attachment.AuthorName + "\n"
@@ -1572,7 +1572,7 @@ func parseMatterpollToMsg(attachments []*model.SlackAttachment, unicode bool) st
 
 		for _, action := range attachment.Actions {
 			if strings.HasPrefix(action.Id, "vote") {
-				msg += prefix + "• " + action.Name + "\n"
+				msg += prefix + "• " + action.Name + "\n"
 			}
 		}
 
@@ -1588,7 +1588,7 @@ func parseMatterpollToMsg(attachments []*model.SlackAttachment, unicode bool) st
 		}
 
 		for _, field := range attachment.Fields {
-			msg += prefix + "• " + field.Title + ": "
+			msg += prefix + "• " + field.Title + ": "
 			lines := strings.Split(fmt.Sprintf("%s", field.Value), "\n")
 			newPrefix := ""
 			for _, text := range lines {
@@ -1609,22 +1609,22 @@ func parseMessageAttachments(attachments []*model.SlackAttachment, useFallback b
 		prefixChar = "┃"
 	}
 	for _, attachment := range attachments {
-		prefix := "\033[1m" + prefixChar + "\033[0m "
+		prefix := "\033[1m" + prefixChar + "\033[0m "
 		switch {
 		// https://docs.slack.dev/tools/node-slack-sdk/reference/web-api/interfaces/MessageAttachment/#color
 		case attachment.Color == "danger":
-			prefix = "\033[31m" + prefixChar + "\033[0m "
+			prefix = "\033[31m" + prefixChar + "\033[0m "
 		case attachment.Color == "good":
-			prefix = "\033[32m" + prefixChar + "\033[0m "
+			prefix = "\033[32m" + prefixChar + "\033[0m "
 		case attachment.Color == "warning":
-			prefix = "\033[33m" + prefixChar + "\033[0m "
+			prefix = "\033[33m" + prefixChar + "\033[0m "
 		case strings.HasPrefix(attachment.Color, "#"):
 			hex := strings.TrimPrefix(attachment.Color, "#")
 			rr, _ := strconv.ParseInt(hex[0:2], 16, 0)
 			gg, _ := strconv.ParseInt(hex[2:4], 16, 0)
 			bb, _ := strconv.ParseInt(hex[4:6], 16, 0)
 			// https://modern.ircdocs.horse/formatting.html#hex-color
-			prefix = fmt.Sprintf("\033[1;38;2;%d;%d;%dm%s\033[0m ", int(rr), int(gg), int(bb), prefixChar)
+			prefix = fmt.Sprintf("\033[1;38;2;%d;%d;%dm%s\033[0m ", int(rr), int(gg), int(bb), prefixChar)
 		}
 
 		if useFallback {
@@ -1635,7 +1635,7 @@ func parseMessageAttachments(attachments []*model.SlackAttachment, useFallback b
 			if line == "" {
 				line, _, _ = strings.Cut(attachment.Text, "\n")
 				if attachment.AuthorName != "" {
-					line = attachment.AuthorName + ": " + line
+					line = attachment.AuthorName + ": " + line
 				}
 			}
 
@@ -1645,7 +1645,7 @@ func parseMessageAttachments(attachments []*model.SlackAttachment, useFallback b
 		if attachment.AuthorName != "" {
 			msg += prefix + attachment.AuthorName
 			if attachment.AuthorLink != "" {
-				msg += " (" + attachment.AuthorLink + ")"
+				msg += " (" + attachment.AuthorLink + ")"
 			}
 			msg += "\n"
 		}

--- a/vendor/github.com/muesli/reflow/wordwrap/wordwrap.go
+++ b/vendor/github.com/muesli/reflow/wordwrap/wordwrap.go
@@ -124,7 +124,7 @@ func (w *WordWrap) Write(b []byte) (int, error) {
 
 			w.addWord()
 			w.addNewLine()
-		} else if unicode.IsSpace(c) {
+		} else if unicode.IsSpace(c) && c != '\u00a0' {
 			// end of current word
 			w.addWord()
 			_, _ = w.space.WriteRune(c)


### PR DESCRIPTION
Also includes https://github.com/muesli/reflow/pull/87