### PR TITLE
Include fencing and change to bold for inline code

### DIFF
--- a/utils/formatters.go
+++ b/utils/formatters.go
@@ -126,7 +126,8 @@ func Markdown2irc(msg string, blockQuoteChar string) string {
 
 	// Code / Monospace 0x11
 	for _, re := range codeRegExp {
-		msg = re.ReplaceAllString(msg, "\x11\x030,14$1\x03\x11")
+		// Not all IRC clients support monospace (0x11) so keep the fence and make it bold as well
+		msg = re.ReplaceAllString(msg, "`\x11\x02$1\x02\x11`")
 	}
 
 	// Block quotes


### PR DESCRIPTION
Not all IRC clients support monospace (0x11) per https://modern.ircdocs.horse/formatting#monospace so continue to include the fencing and make it bold so it's more noticeable.