### PR TITLE
Surface errors to user when cannot send DM as well as handler errors

### DIFF
--- a/mm-go-irckit/server.go
+++ b/mm-go-irckit/server.go
@@ -317,9 +317,9 @@ func (s *server) welcome(u *User) error {
 			Trailing: fmt.Sprintf("This server was created %s", s.created.Format(time.UnixDate)),
 		},
 		&irc.Message{
-			Prefix:   s.Prefix(),
-			Command:  irc.RPL_MYINFO,
-			Params:   []string{u.Nick, s.config.Name, s.config.Version, "o", "o"},
+			Prefix:  s.Prefix(),
+			Command: irc.RPL_MYINFO,
+			Params:  []string{u.Nick, s.config.Name, s.config.Version, "o", "o"},
 		},
 		&irc.Message{
 			Prefix:   s.Prefix(),
@@ -362,7 +362,9 @@ func (s *server) handle(u *User) {
 			if err == ErrUnknownCommand {
 				// TODO: Emit event?
 			} else if err != nil {
-				logger.Errorf("handler error for %s: %s", u.ID(), err.Error())
+				errMsg := fmt.Sprintf("%s: %#v", err.Error(), msg)
+				logger.Errorf("handler error for %s: %s", u.ID(), errMsg)
+				s.EncodeMessage(u, irc.PRIVMSG, []string{u.Nick}, errMsg) //nolint:errcheck
 			}
 		}(msg)
 	}

--- a/mm-go-irckit/server_commands.go
+++ b/mm-go-irckit/server_commands.go
@@ -449,6 +449,7 @@ func CmdPrivMsg(s Server, u *User, msg *irc.Message) error {
 
 			msgID, err2 := u.br.MsgUser(toUser.User, msg.Trailing)
 			if err2 != nil {
+				u.MsgSpoofUser(u, u.br.Protocol(), "msg: "+msg.Trailing+" could not be sent "+err2.Error())
 				return err2
 			}
 			u.msgLastMutex.Lock()


### PR DESCRIPTION
Fixes #477 where for channel messages, we surface the error but not for DMs.

In addition to this, surface any handler errors as well.