### PR TITLE
Better handling of CTCP ACTION (/me)

### DIFF
--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -324,13 +324,23 @@ func (m *Mattermost) MsgChannel(channelID, text string) (string, error) {
 }
 
 func (m *Mattermost) MsgChannelThread(channelID, parentID, text string) (string, error) {
-	props := make(map[string]interface{})
-	props["matterircd_"+m.mc.User.Id] = m.instanceTag
+	props := map[string]interface{}{
+		"matterircd_" + m.mc.User.Id: m.instanceTag,
+	}
+
+	msgType := ""
+	// CTCP ACTION (/me)
+	if strings.HasPrefix(text, "\x01ACTION ") {
+		text = strings.TrimPrefix(text, "\x01ACTION ")
+		text = strings.TrimSuffix(text, "\x01")
+		msgType = "me"
+	}
 
 	post := &model.Post{
 		ChannelId: channelID,
 		Message:   text,
 		RootId:    parentID,
+		Type:      msgType,
 	}
 
 	post.SetProps(props)
@@ -354,6 +364,7 @@ func (m *Mattermost) MsgChannelThread(channelID, parentID, text string) (string,
 		ChannelId: channelID,
 		Message:   text,
 		RootId:    replyPost.RootId,
+		Type:      msgType,
 	}
 
 	post.SetProps(props)
@@ -839,6 +850,8 @@ func maybeShorten(msg string, newLen int, uncounted string, unicode bool) string
 		b.WriteString(word)
 	}
 
+	// We also want to reset any formatting which can be carried over from shortening
+	b.WriteByte('\x0f')
 	b.WriteByte(' ')
 	b.WriteString(ellipsis)
 
@@ -997,7 +1010,7 @@ func (m *Mattermost) handleWsActionPost(rmsg *model.WebSocketEvent) {
 			}
 
 			d := &bridge.DirectMessageEvent{
-				Text:      "\x01ACTION updated topic to: " + topic + " \x01",
+				Text:      "\x01ACTION updated topic to: " + topic + "\x01",
 				ChannelID: data.ChannelId,
 				MessageID: data.Id,
 				Event:     "dm_topic",
@@ -1067,7 +1080,7 @@ func (m *Mattermost) handleWsActionPost(rmsg *model.WebSocketEvent) {
 
 	switch {
 	case data.Type == "me":
-		msg = "\x01ACTION " + strings.Trim(msg, "*") + " \x01"
+		msg = "\x01ACTION " + msg + postfix + "\x01"
 	case data.Type == "slack_attachment":
 		useFallback := msg == ""
 		// https://docs.slack.dev/tools/node-slack-sdk/reference/web-api/interfaces/MessageAttachment/
@@ -1094,7 +1107,7 @@ func (m *Mattermost) handleWsActionPost(rmsg *model.WebSocketEvent) {
 	if strings.HasSuffix(msg, "\n") { //nolint:gosimple
 		msg = msg[:len(msg)-1]
 	}
-	if postfix != "" {
+	if postfix != "" && data.Type != "me" {
 		msg += postfix
 	}
 

--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -45,6 +45,7 @@ func New(v *viper.Viper, cred bridge.Credentials, eventChan chan *bridge.Event, 
 	ourlog := logrus.New()
 	ourlog.SetFormatter(&prefixed.TextFormatter{
 		PrefixPadding: 13,
+		DisableColors: false,
 		FullTimestamp: true,
 	})
 	logger = ourlog.WithFields(logrus.Fields{"prefix": "bridge/slack"})
@@ -174,6 +175,13 @@ func (s *Slack) MsgUser(username, text string) (string, error) {
 		return "", err
 	}
 
+	// CTCP ACTION (/me)
+	if strings.HasPrefix(text, "\x01ACTION ") {
+		text = strings.TrimPrefix(text, "\x01ACTION ")
+		text = strings.TrimSuffix(text, "\x01")
+		text = "*" + text + "*"
+	}
+
 	opts := s.createSlackMsgOption(text)
 
 	_, msgID, err := s.sc.PostMessage(dchannel.ID, opts...)
@@ -189,6 +197,13 @@ func (s *Slack) MsgUser(username, text string) (string, error) {
 }
 
 func (s *Slack) MsgChannel(channelID, text string) (string, error) {
+	// CTCP ACTION (/me)
+	if strings.HasPrefix(text, "\x01ACTION ") {
+		text = strings.TrimPrefix(text, "\x01ACTION ")
+		text = strings.TrimSuffix(text, "\x01")
+		text = "*" + text + "*"
+	}
+
 	opts := s.createSlackMsgOption(text)
 
 	_, msgID, err := s.sc.PostMessage(strings.ToUpper(channelID), opts...)

--- a/mm-go-irckit/server_commands.go
+++ b/mm-go-irckit/server_commands.go
@@ -368,12 +368,6 @@ func CmdPrivMsg(s Server, u *User, msg *irc.Message) error {
 			msg.Trailing = msg.Params[1]
 		}
 	}
-	// CTCP ACTION (/me)
-	if strings.HasPrefix(msg.Trailing, "\x01ACTION ") {
-		msg.Trailing = strings.ReplaceAll(msg.Trailing, "\x01ACTION ", "")
-		msg.Trailing = strings.ReplaceAll(msg.Trailing, "\x01", "")
-		msg.Trailing = "*" + msg.Trailing + "*"
-	}
 
 	// strip IRC colors
 	msg.Trailing = colorRegExp.ReplaceAllString(msg.Trailing, "")


### PR DESCRIPTION
For Mattermost, that's setting the post type to "me" per #281.

Also, we want to make sure the "\x01" is at the end of any additional strings we append (such as deleted/edited).