### PR TITLE
Reduce Mattermost API calls by replacing user status calls with WebSocket and caching

### DIFF
--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -1406,6 +1406,8 @@ func (m *Mattermost) handleStatusChangeEvent(rmsg *model.WebSocketEvent) {
 		return
 	}
 
+	m.mc.SetUserStatus(info.UserId, info.Status)
+
 	event := &bridge.Event{
 		Type: "status_change",
 		Data: &bridge.StatusChangeEvent{

--- a/vendor/github.com/matterbridge/matterclient/matterclient.go
+++ b/vendor/github.com/matterbridge/matterclient/matterclient.go
@@ -86,6 +86,9 @@ type Client struct {
 
 	lastWsActivity atomic.Int64
 	connectedAt    atomic.Int64
+
+	UserStatusMutex sync.RWMutex
+	UserStatuses    map[string]string
 }
 
 var Matterircd bool
@@ -109,13 +112,14 @@ func New(login string, pass string, team string, server string, mfatoken string)
 	cache, _ := lru.New(500)
 
 	return &Client{
-		Credentials: cred,
-		MessageChan: make(chan *Message, 100),
-		Users:       make(map[string]*model.User),
-		rootLogger:  rootLogger,
-		lruCache:    cache,
-		logger:      rootLogger.WithFields(logrus.Fields{"prefix": "matterclient"}),
-		aliveChan:   make(chan bool),
+		Credentials:  cred,
+		MessageChan:  make(chan *Message, 100),
+		Users:        make(map[string]*model.User),
+		UserStatuses: make(map[string]string),
+		rootLogger:   rootLogger,
+		lruCache:     cache,
+		logger:       rootLogger.WithFields(logrus.Fields{"prefix": "matterclient"}),
+		aliveChan:    make(chan bool),
 	}
 }
 
@@ -173,6 +177,11 @@ func (m *Client) Login() error {
 	m.logger.Debug("starting wsreceiver")
 
 	go m.WsReceiver(ctx)
+
+	if m.WsClient != nil {
+		m.logger.Debug("requesting initial user statuses for cache")
+		m.WsClient.GetStatuses()
+	}
 
 	if m.OnWsConnect != nil {
 		m.logger.Debug("executing OnWsConnect()")
@@ -586,6 +595,7 @@ func (m *Client) doCheckAlive() error {
 
 	connectedUnix := m.connectedAt.Load()
 	uptime := time.Since(time.Unix(connectedUnix, 0)).Round(time.Second)
+
 	lastActiveUnix := m.lastWsActivity.Load()
 	timeSinceActivity := time.Since(time.Unix(lastActiveUnix, 0))
 
@@ -690,9 +700,9 @@ func (m *Client) WsReceiver(ctx context.Context) {
 				continue
 			}
 
-			m.lastWsActivity.Store(time.Now().Unix())
-
 			m.logger.Debugf("WsReceiver event: %#v", event)
+
+			m.lastWsActivity.Store(time.Now().Unix())
 
 			eventType := event.EventType()
 

--- a/vendor/github.com/matterbridge/matterclient/users.go
+++ b/vendor/github.com/matterbridge/matterclient/users.go
@@ -13,64 +13,61 @@ func (m *Client) GetNickName(userID string) string {
 }
 
 func (m *Client) GetStatus(userID string) string {
+	m.UserStatusMutex.RLock()
+	status, ok := m.UserStatuses[userID]
+	m.UserStatusMutex.RUnlock()
+	if ok {
+		return status
+	}
+
 	res, _, err := m.Client.GetUserStatus(userID, "")
 	if err != nil {
-		return ""
+		return "offline"
 	}
 
-	if res.Status == model.StatusAway {
-		return "away"
-	}
-
-	if res.Status == model.StatusOnline {
-		return "online"
-	}
-
-	return "offline"
+	return m.SetUserStatus(userID, res.Status)
 }
 
 func (m *Client) GetStatuses() map[string]string {
 	statuses := make(map[string]string, len(m.Users))
+	var missingIDs []string
+
+	m.UserStatusMutex.RLock()
+	for id := range m.Users {
+		if status, ok := m.UserStatuses[id]; ok {
+			statuses[id] = status
+		} else {
+			missingIDs = append(missingIDs, id)
+		}
+	}
+	m.UserStatusMutex.RUnlock()
+
+	if len(missingIDs) == 0 {
+		return statuses
+	}
 
 	const batchSize = 5000
-	batch := make([]string, 0, batchSize)
+	for i := 0; i < len(missingIDs); i += batchSize {
+		end := i + batchSize
+		if end > len(missingIDs) {
+			end = len(missingIDs)
+		}
 
-	// Inline helper to handle the API call and mapping for a specific batch
-	processBatch := func(ids []string) error {
-		res, _, err := m.Client.GetUsersStatusesByIds(ids)
+		batch := missingIDs[i:end]
+		res, _, err := m.Client.GetUsersStatusesByIds(batch)
 		if err != nil {
-			return err
+			continue
 		}
 
-		for _, status := range res {
-			switch status.Status {
-			case model.StatusOnline:
-				statuses[status.UserId] = "online"
-			case model.StatusAway:
-				statuses[status.UserId] = "away"
-			default:
-				statuses[status.UserId] = "offline"
-			}
-		}
-		return nil
-	}
-
-	for id := range m.Users {
-		batch = append(batch, id)
-
-		// Once we hit the batch limit, execute the API call
-		if len(batch) == batchSize {
-			if err := processBatch(batch); err != nil {
-				return statuses
-			}
-			// Reset the batch slice length to 0, while keeping its underlying capacity
-			batch = batch[:0]
+		for _, st := range res {
+			statuses[st.UserId] = m.SetUserStatus(st.UserId, st.Status)
 		}
 	}
 
-	// Catch any remaining IDs that didn't cleanly fill up the final batch
-	if len(batch) > 0 {
-		_ = processBatch(batch)
+	for _, id := range missingIDs {
+		if _, ok := statuses[id]; !ok {
+			statuses[id] = "offline"
+		}
 	}
 
 	return statuses
@@ -130,6 +127,25 @@ func (m *Client) GetUsers() map[string]*model.User {
 	}
 
 	return users
+}
+
+func (m *Client) SetUserStatus(userID string, rawStatus string) string {
+	statusStr := "offline"
+	switch rawStatus {
+	case model.StatusOnline:
+		statusStr = "online"
+	case model.StatusAway:
+		statusStr = "away"
+	}
+
+	m.UserStatusMutex.Lock()
+	if m.UserStatuses == nil {
+		m.UserStatuses = make(map[string]string)
+	}
+	m.UserStatuses[userID] = statusStr
+	m.UserStatusMutex.Unlock()
+
+	return statusStr
 }
 
 func (m *Client) UpdateUsers() error {


### PR DESCRIPTION
Part of work for #627.

It also speeds up initial start up time as well. We still use the HTTP API for user statuses, but that's only on fallback.

On a server with around 1500 users, I get ~541 API calls without this change. With this change, it reduces it down to 435.

Unfortunately, Mattermost only permits us to do this with user statuses - it would be nice if it were possible with users and channels as well.