### PR TITLE
Ensure all message channels and workers/goroutines shut down on logout

### DIFF
--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -287,19 +287,20 @@ func (m *Mattermost) Logout() error {
 			logger.Error("logout failed")
 		}
 		logger.Info("logout succeeded")
-
-		m.eventChan <- &bridge.Event{
-			Type: "logout",
-			Data: &bridge.LogoutEvent{},
-		}
-
-		m.mc.WsQuit = true
-
-		for _, c := range m.quitChan {
-			c <- struct{}{}
-		}
 	}
 
+	m.eventChan <- &bridge.Event{
+		Type: "logout",
+		Data: &bridge.LogoutEvent{},
+	}
+
+	m.mc.WsQuit = true
+
+	for _, c := range m.quitChan {
+		close(c)
+	}
+
+	m.quitChan = nil
 	m.connected = false
 
 	return nil


### PR DESCRIPTION
Otherwise, each time we disconnect, reconnect and re-login, we end up with lingering workers/goroutines.

After one disconnect & reconnect + login:

```
[ubuntu@irc-proxy ~]$ curl -s "http://localhost:6060/debug/pprof/goroutine?debug=2"  | grep '^goroutine' | grep minutes
goroutine 1 [select (no cases), 1328 minutes]:
goroutine 18 [select, 7 minutes]:
goroutine 8 [sync.WaitGroup.Wait, 1328 minutes]:
goroutine 12 [IO wait, 346 minutes]:
goroutine 35 [chan receive, 346 minutes]:
goroutine 11080 [select, 7 minutes]:
goroutine 93 [select, 348 minutes]:
goroutine 94 [select, 348 minutes]:
goroutine 95 [select, 348 minutes]:
goroutine 96 [select, 348 minutes]:
goroutine 97 [select, 346 minutes]:
goroutine 98 [select, 348 minutes]:
goroutine 99 [select, 348 minutes]:
goroutine 100 [select, 346 minutes]:
goroutine 101 [select, 348 minutes]:
goroutine 571 [chan receive, 348 minutes]:
goroutine 11136 [select, 3 minutes]:
goroutine 18273 [IO wait, 3 minutes]:
goroutine 2027 [chan receive, 346 minutes]:
```

After another disconnect & reconnect + login:

```
[ubuntu@irc-proxy ~]$ curl -s "http://localhost:6060/debug/pprof/goroutine?debug=2"  | grep '^goroutine' | grep minutes
goroutine 1 [select (no cases), 1334 minutes]:
goroutine 18 [select, 7 minutes]:
goroutine 8 [sync.WaitGroup.Wait, 1334 minutes]:
goroutine 12 [IO wait, 7 minutes]:
goroutine 11038 [chan receive, 7 minutes]:
goroutine 35 [chan receive, 352 minutes]:
goroutine 11160 [select, 7 minutes]:
goroutine 93 [select, 354 minutes]:
goroutine 94 [select, 354 minutes]:
goroutine 95 [select, 354 minutes]:
goroutine 96 [select, 354 minutes]:
goroutine 97 [select, 352 minutes]:
goroutine 98 [select, 354 minutes]:
goroutine 99 [select, 354 minutes]:
goroutine 100 [select, 352 minutes]:
goroutine 101 [select, 354 minutes]:
goroutine 11155 [select, 7 minutes]:
goroutine 571 [chan receive, 354 minutes]:
goroutine 11153 [select, 7 minutes]:
goroutine 2027 [chan receive, 352 minutes]:
goroutine 11158 [select, 7 minutes]:
goroutine 11156 [select, 7 minutes]:
goroutine 11157 [select, 7 minutes]:
goroutine 11159 [select, 7 minutes]:
goroutine 18487 [select, 7 minutes]:
goroutine 11161 [select, 7 minutes]:
goroutine 11154 [select, 7 minutes]:
goroutine 18563 [select, 3 minutes]:
[ubuntu@irc-proxy ~]$
```

Continuation of #662 and also helps with #626 where we ensure memory isn't leaked and properly reclaimed.