### PR TITLE
Reduce Mattermost API calls by removing the need to call UpdateChannels() to get *all* channels

### DIFF
--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -139,9 +139,6 @@ func (m *Mattermost) loginToMattermost(onWsConnect func()) (*matterclient.Client
 
 //nolint:cyclop
 func (m *Mattermost) handleWsMessage(quitChan chan struct{}) {
-	updateChannelsThrottle := time.NewTicker(time.Second * 60)
-	defer updateChannelsThrottle.Stop()
-
 	for {
 		if m.mc.WsQuit {
 			logger.Debug("exiting handleWsMessage")
@@ -170,20 +167,13 @@ func (m *Mattermost) handleWsMessage(quitChan chan struct{}) {
 			case model.WebsocketEventUserRemoved:
 				m.handleWsActionUserRemoved(message.Raw)
 			case model.WebsocketEventUserAdded:
-				// check if we have the users/channels in our cache. If not update
-				m.checkWsActionMessage(message.Raw, updateChannelsThrottle)
 				m.handleWsActionUserAdded(message.Raw)
 			case model.WebsocketEventChannelCreated:
-				// check if we have the users/channels in our cache. If not update
-				m.checkWsActionMessage(message.Raw, updateChannelsThrottle)
 				m.handleWsActionChannelCreated(message.Raw)
 			case model.WebsocketEventChannelDeleted:
-				// check if we have the users/channels in our cache. If not update
-				m.checkWsActionMessage(message.Raw, updateChannelsThrottle)
 				m.handleWsActionChannelDeleted(message.Raw)
 			case model.WebsocketEventChannelRestored:
-				// check if we have the users/channels in our cache. If not update
-				m.checkWsActionMessage(message.Raw, updateChannelsThrottle)
+				m.handleWsActionChannelCreated(message.Raw)
 			case model.WebsocketEventChannelUpdated:
 				m.handleWsActionPost(message.Raw)
 			case model.WebsocketEventUserUpdated:
@@ -501,7 +491,10 @@ func (m *Mattermost) GetChannelName(channelID string) string {
 	channelName := m.mc.GetChannelName(channelID)
 
 	if channelName == "" {
-		m.mc.UpdateChannels()
+		channel := m.mc.GetChannel(channelID)
+		if channel == nil {
+			logger.Debugf("Could not resolve missing channel name for %s", channelID)
+		}
 	}
 
 	channelName = m.mc.GetChannelName(channelID)

--- a/mm-go-irckit/server_commands.go
+++ b/mm-go-irckit/server_commands.go
@@ -323,8 +323,6 @@ func CmdPart(s Server, u *User, msg *irc.Message) error {
 		}
 	}
 
-	u.br.UpdateChannels()
-
 	return err
 }
 

--- a/vendor/github.com/matterbridge/matterclient/matterclient.go
+++ b/vendor/github.com/matterbridge/matterclient/matterclient.go
@@ -1117,11 +1117,8 @@ func (m *Client) maintainUsersCache(event *model.WebSocketEvent) {
 
 	case model.WebsocketEventChannelDeleted:
 		if channelID, ok := event.GetData()["channel_id"].(string); ok && channelID != "" {
-			m.Users.mu.Lock()
-			delete(m.Users.channelData, channelID)
-			delete(m.Users.joinedChannels, channelID)
-			delete(m.Users.channels, channelID)
-			m.Users.mu.Unlock()
+			// Mattermost soft-deletes channels. We keep the channel and users in our
+			// local cache to gracefully handle history, references, or restorations.
 			m.Users.lastUpdated.Store(time.Now().Unix())
 		}
 	}


### PR DESCRIPTION
Continuation of #656, #667, #668, and #687.

Part of work for #627.