### PR TITLE
Rework config, fix concurrent config map read and map write error

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -2,6 +2,8 @@ package bridge
 
 import (
 	"time"
+
+	"github.com/42wim/matterircd/config"
 )
 
 type Bridger interface {
@@ -57,6 +59,10 @@ type Bridger interface {
 	GetFileLinks(fileIDs []string) []string
 
 	GetLastSentMsgs() []string
+
+	Config() any
+	BridgeConfig() *config.BridgeConfig
+	FormatterConfig() *config.FormatterConfig
 }
 
 type ChannelInfo struct {

--- a/bridge/mastodon/mastodon.go
+++ b/bridge/mastodon/mastodon.go
@@ -8,11 +8,11 @@ import (
 	"sync"
 
 	"github.com/42wim/matterircd/bridge"
+	"github.com/42wim/matterircd/config"
 	"github.com/davecgh/go-spew/spew"
 	strip "github.com/grokify/html-strip-tags-go"
 	"github.com/mattn/go-mastodon"
 	logger "github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 )
 
 type Mastodon struct {
@@ -23,25 +23,28 @@ type Mastodon struct {
 	eventChanIn chan mastodon.Event
 	onConnect   func()
 	sync.RWMutex
-	v *viper.Viper
+
+	cfg *config.Config
 }
 
-func New(v *viper.Viper, cred bridge.Credentials, eventChan chan *bridge.Event, onConnect func()) (bridge.Bridger, error) {
+func New(cfg *config.Config, cred bridge.Credentials, eventChan chan *bridge.Event, onConnect func()) (bridge.Bridger, error) {
 	m := &Mastodon{
 		credentials: cred,
 		eventChan:   eventChan,
 		onConnect:   onConnect,
-		v:           v,
+		cfg:         cfg,
 	}
 
 	var err error
 
+	rc := cfg.Current()
+
 	logger.SetFormatter(&logger.TextFormatter{FullTimestamp: true})
-	if v.GetBool("debug") {
+	if rc.Debug {
 		logger.SetLevel(logger.DebugLevel)
 	}
 
-	if v.GetBool("trace") {
+	if rc.Trace {
 		logger.SetLevel(logger.TraceLevel)
 	}
 
@@ -211,11 +214,13 @@ func (m *Mastodon) GetChannelID(name, teamID string) string {
 }
 
 func (m *Mastodon) loginToMastodon() (*mastodon.Client, error) {
+	rc := m.cfg.Current()
+
 	mc := mastodon.NewClient(&mastodon.Config{
-		Server:       m.v.GetString("mastodon.server"),
-		ClientID:     m.v.GetString("mastodon.clientid"),
-		ClientSecret: m.v.GetString("mastodon.clientsecret"),
-		AccessToken:  m.v.GetString("mastodon.accesstoken"),
+		Server:       rc.Mastodon.Server,
+		ClientID:     rc.Mastodon.ClientID,
+		ClientSecret: rc.Mastodon.ClientSecret,
+		AccessToken:  rc.Mastodon.AccessToken,
 	})
 
 	// events, err := mc.StreamingPublic(context.Background(), false)

--- a/bridge/mastodon/mastodon.go
+++ b/bridge/mastodon/mastodon.go
@@ -376,3 +376,15 @@ func (m *Mastodon) Topic(channelID string) string {
 func (m *Mastodon) GetLastSentMsgs() []string {
 	return []string{}
 }
+
+func (m *Mastodon) Config() any {
+	return &m.cfg.Current().Mastodon
+}
+
+func (m *Mastodon) BridgeConfig() *config.BridgeConfig {
+	return &m.cfg.Current().Mastodon.Bridge
+}
+
+func (m *Mastodon) FormatterConfig() *config.FormatterConfig {
+	return &m.cfg.Current().Mastodon.Formatter
+}

--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/42wim/matterircd/bridge"
+	"github.com/42wim/matterircd/config"
 	"github.com/42wim/matterircd/utils"
 	"github.com/davecgh/go-spew/spew"
 	lru "github.com/hashicorp/golang-lru"
@@ -20,7 +21,6 @@ import (
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mitchellh/mapstructure"
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 )
 
 type Mattermost struct {
@@ -28,22 +28,26 @@ type Mattermost struct {
 	credentials bridge.Credentials
 	quitChan    []chan struct{}
 	eventChan   chan *bridge.Event
-	v           *viper.Viper
 	connected   bool
 	instanceTag string
 
 	msgParentCache   *lru.Cache
 	msgLastSentCache *lru.Cache
+
+	cfg *config.Config
 }
 
 var logger *logrus.Entry
 
-func New(v *viper.Viper, cred bridge.Credentials, eventChan chan *bridge.Event, onWsConnect func()) (bridge.Bridger, *matterclient.Client, error) {
+func New(cfg *config.Config, cred bridge.Credentials, eventChan chan *bridge.Event, onWsConnect func()) (bridge.Bridger, *matterclient.Client, error) {
 	m := &Mattermost{
 		credentials: cred,
 		eventChan:   eventChan,
-		v:           v,
+		cfg:         cfg,
 	}
+
+	rc := cfg.Current()
+
 	m.msgParentCache, _ = lru.New(100)
 	m.msgLastSentCache, _ = lru.New(10)
 
@@ -54,11 +58,11 @@ func New(v *viper.Viper, cred bridge.Credentials, eventChan chan *bridge.Event, 
 		FullTimestamp: true,
 	})
 	logger = ourlog.WithFields(logrus.Fields{"prefix": "bridge/mattermost"})
-	if v.GetBool("debug") {
+	if rc.Debug {
 		ourlog.SetLevel(logrus.DebugLevel)
 	}
 
-	if v.GetBool("trace") {
+	if rc.Trace {
 		ourlog.SetLevel(logrus.TraceLevel)
 	}
 
@@ -67,11 +71,11 @@ func New(v *viper.Viper, cred bridge.Credentials, eventChan chan *bridge.Event, 
 		return nil, nil, err
 	}
 
-	if v.GetBool("debug") {
+	if rc.Debug {
 		mc.SetLogLevel("debug")
 	}
 
-	if v.GetBool("trace") {
+	if rc.Trace {
 		mc.SetLogLevel("trace")
 	}
 
@@ -91,28 +95,30 @@ func New(v *viper.Viper, cred bridge.Credentials, eventChan chan *bridge.Event, 
 }
 
 func (m *Mattermost) loginToMattermost(onWsConnect func()) (*matterclient.Client, error) {
+	rc := m.cfg.Current()
+
 	matterclient.Matterircd = true
 
 	mc := matterclient.New(m.credentials.Login, m.credentials.Pass, m.credentials.Team, m.credentials.Server, m.credentials.MFAToken)
-	if m.v.GetBool("mattermost.Insecure") {
+	if rc.Mattermost.Insecure {
 		mc.Credentials.NoTLS = true
 	}
 
-	mc.AntiIdle = !m.v.GetBool("mattermost.DisableAutoView") || m.v.GetBool("mattermost.ForceAntiIdle")
-	mc.AntiIdleChan = m.v.GetString("mattermost.AntiIdleChannel")
-	mc.AntiIdleIntvl = m.v.GetInt("mattermost.AntiIdleInterval")
+	mc.AntiIdle = !rc.Mattermost.DisableAutoView || rc.Mattermost.ForceAntiIdle
+	mc.AntiIdleChan = rc.Mattermost.AntiIdleChannel
+	mc.AntiIdleIntvl = rc.Mattermost.AntiIdleInterval
 	mc.OnWsConnect = onWsConnect
 
-	mc.Timeout = m.v.GetInt("ClientTimeout")
+	mc.Timeout = rc.ClientTimeout
 	if mc.Timeout == 0 {
 		mc.Timeout = 10
 	}
 
-	if m.v.GetBool("debug") {
+	if rc.Debug {
 		mc.SetLogLevel("debug")
 	}
 
-	mc.Credentials.SkipTLSVerify = m.v.GetBool("mattermost.SkipTLSVerify")
+	mc.Credentials.SkipTLSVerify = rc.Mattermost.SkipTLSVerify
 
 	logger.Infof("login as %s (team: %s) on %s", m.credentials.Login, m.credentials.Team, m.credentials.Server)
 
@@ -488,6 +494,8 @@ func (m *Mattermost) GetChannelName(channelID string) string {
 		return channelID
 	}
 
+	rc := m.cfg.Current()
+
 	channelName := m.mc.GetChannelName(channelID)
 
 	if channelName == "" {
@@ -508,10 +516,10 @@ func (m *Mattermost) GetChannelName(channelID string) string {
 	teamName := m.mc.GetTeamName(teamID)
 
 	if channelName != "" {
-		if (teamName != "" && teamID != m.mc.Team.ID) || m.v.GetBool("mattermost.PrefixMainTeam") {
+		if (teamName != "" && teamID != m.mc.Team.ID) || rc.Mattermost.PrefixMainTeam {
 			name = "#" + teamName + "/" + channelName
 		}
-		if teamID == m.mc.Team.ID && !m.v.GetBool("mattermost.PrefixMainTeam") {
+		if teamID == m.mc.Team.ID && !rc.Mattermost.PrefixMainTeam {
 			name = "#" + channelName
 		}
 		if teamID == "G" {
@@ -620,8 +628,10 @@ func (m *Mattermost) createUser(mmuser *model.User) *bridge.UserInfo {
 		return &bridge.UserInfo{}
 	}
 
+	rc := m.cfg.Current()
+
 	nick := mmuser.Username
-	if m.v.GetBool("mattermost.PreferNickname") && isValidNick(mmuser.Nickname) {
+	if rc.Mattermost.PreferNickname && isValidNick(mmuser.Nickname) {
 		nick = mmuser.Nickname
 	}
 
@@ -704,15 +714,17 @@ func (m *Mattermost) wsActionPostSkip(rmsg *model.WebSocketEvent) bool {
 		return true
 	}
 
-	disableMarkdown := m.v.GetBool("mattermost.disablemarkdown")
-	disableEmoji := m.v.GetBool("mattermost.disableemoji")
-	useUnicode := m.v.GetBool("mattermost.unicode")
+	rc := m.cfg.Current()
+
+	disableMarkdown := rc.Mattermost.DisableMarkdown
+	disableEmoji := rc.Mattermost.DisableEmoji
+	useUnicode := rc.Mattermost.Unicode
 	blockquoteChar := blockquoteCharNonUnicode
-	inlineCode := m.v.GetString("mattermost.markdowninlinecode")
+	inlineCode := rc.Mattermost.MarkdownInlineCode
 	if useUnicode {
 		blockquoteChar = blockquoteCharUnicode
 	}
-	shortenMsgLen := m.v.GetInt("mattermost.ShortenRepliesTo")
+	shortenMsgLen := rc.Mattermost.ShortenRepliesTo
 
 	var data model.Post
 	if err := json.Unmarshal([]byte(postData), &data); err != nil {
@@ -735,7 +747,7 @@ func (m *Mattermost) wsActionPostSkip(rmsg *model.WebSocketEvent) bool {
 	}
 
 	// Show own edited / deleted
-	if !m.v.GetBool("disableshowownmodified") && (rmsg.EventType() == model.WebsocketEventPostEdited || rmsg.EventType() == model.WebsocketEventPostDeleted) {
+	if !rc.Mattermost.DisableShowOwnModified && (rmsg.EventType() == model.WebsocketEventPostEdited || rmsg.EventType() == model.WebsocketEventPostDeleted) {
 		return false
 	}
 
@@ -750,7 +762,7 @@ func (m *Mattermost) wsActionPostSkip(rmsg *model.WebSocketEvent) bool {
 	var sbSuffix strings.Builder
 	if data.RootId != "" {
 		msgID = data.RootId
-		if !m.v.GetBool("mattermost.hidereplies") {
+		if !rc.Mattermost.HideReplies {
 			parentReplyMsg, err := m.getParentReplyMsg(data.RootId, nil, shortenMsgLen, "@", useUnicode)
 			if err == nil {
 				sbSuffix.WriteString(parentReplyMsg)
@@ -840,11 +852,13 @@ var markdownReplacer = strings.NewReplacer(
 func (m *Mattermost) getParentReplyMsg(parentID string, preFetchedPost *model.Post, newLen int, uncounted string, unicode bool) (string, error) {
 	var replyMessage string
 
-	disableMarkdown := m.v.GetBool("mattermost.disablemarkdown")
-	disableEmoji := m.v.GetBool("mattermost.disableemoji")
-	useUnicode := m.v.GetBool("mattermost.unicode")
+	rc := m.cfg.Current()
+
+	disableMarkdown := rc.Mattermost.DisableMarkdown
+	disableEmoji := rc.Mattermost.DisableEmoji
+	useUnicode := rc.Mattermost.Unicode
 	blockquoteChar := blockquoteCharNonUnicode
-	inlineCode := m.v.GetString("mattermost.markdowninlinecode")
+	inlineCode := rc.Mattermost.MarkdownInlineCode
 	if useUnicode {
 		blockquoteChar = blockquoteCharUnicode
 	}
@@ -932,11 +946,13 @@ func (m *Mattermost) handleWsActionPost(rmsg *model.WebSocketEvent) {
 		return
 	}
 
-	useUnicode := m.v.GetBool("mattermost.unicode")
+	rc := m.cfg.Current()
+
+	useUnicode := rc.Mattermost.Unicode
 
 	var sbSuffix strings.Builder
-	if !m.v.GetBool("mattermost.hidereplies") && data.RootId != "" {
-		parentReplyMsg, err := m.getParentReplyMsg(data.RootId, nil, m.v.GetInt("mattermost.ShortenRepliesTo"), "@", useUnicode)
+	if !rc.Mattermost.HideReplies && data.RootId != "" {
+		parentReplyMsg, err := m.getParentReplyMsg(data.RootId, nil, rc.Mattermost.ShortenRepliesTo, "@", useUnicode)
 		if err != nil {
 			logger.Errorf("Unable to get parent post for %#v", data) //nolint:govet
 		} else {
@@ -1173,7 +1189,7 @@ func (m *Mattermost) handleWsActionPost(rmsg *model.WebSocketEvent) {
 		m.eventChan <- event
 	default:
 		messageType := ""
-		if !m.v.GetBool("mattermost.disabledefaultmentions") && channelMentionsRegExp.MatchString(data.Message) {
+		if !rc.Mattermost.DisableDefaultMentions && channelMentionsRegExp.MatchString(data.Message) {
 			messageType = "notice"
 		}
 
@@ -1445,9 +1461,10 @@ func (m *Mattermost) handleReactionEvent(rmsg *model.WebSocketEvent) {
 	userID := m.GetUser(reaction.UserId)
 	sender := userID
 	receiver := m.GetMe()
+	rc := m.cfg.Current()
 
 	// Don't show our own reaction messages unless mattermost.showownreactions is enabled.
-	if userID.Me && !m.v.GetBool("mattermost.showownreactions") {
+	if userID.Me && !rc.Mattermost.ShowOwnReactions {
 		logger.Debugf("Not showing own reaction: %s: %s", rmsg.EventType(), reaction.EmojiName)
 		return
 	}
@@ -1485,8 +1502,8 @@ func (m *Mattermost) handleReactionEvent(rmsg *model.WebSocketEvent) {
 		if parentPost.RootId != "" {
 			parentID = parentPost.RootId
 		}
-		if !m.v.GetBool("mattermost.hidereplies") {
-			replyMsg, err := m.getParentReplyMsg(reaction.PostId, parentPost, m.v.GetInt("mattermost.ShortenRepliesTo"), "@", m.v.GetBool("mattermost.unicode"))
+		if !rc.Mattermost.HideReplies {
+			replyMsg, err := m.getParentReplyMsg(reaction.PostId, parentPost, rc.Mattermost.ShortenRepliesTo, "@", rc.Mattermost.Unicode)
 			if err == nil {
 				sbSuffix.WriteString(replyMsg)
 			}
@@ -1707,16 +1724,18 @@ const blockQuoteCharDefault = ">"
 
 //nolint:funlen,gocognit,gocyclo
 func (m *Mattermost) parseMessageAttachments(attachments []*model.SlackAttachment, useFallback bool) string {
-	useUnicode := m.v.GetBool("mattermost.unicode")
-	syntaxHighlighting := m.v.GetString("mattermost.syntaxhighlighting")
-	codeBlockPrefix := m.v.GetString("mattermost.codeblockprefix")
-	disableMarkdown := m.v.GetBool("mattermost.disablemarkdown")
-	disableEmoji := m.v.GetBool("mattermost.disableemoji")
+	rc := m.cfg.Current()
+
+	useUnicode := rc.Mattermost.Unicode
+	syntaxHighlighting := rc.Mattermost.SyntaxHighlighting
+	codeBlockPrefix := rc.Mattermost.CodeBlockPrefix
+	disableMarkdown := rc.Mattermost.DisableMarkdown
+	disableEmoji := rc.Mattermost.DisableEmoji
 
 	prefixChar := messageAttachmentCharNonUnicode
 	spaceChar := messageAttachmentSpaceNonUnicode
 	blockquoteChar := blockquoteCharNonUnicode
-	inlineCode := m.v.GetString("mattermost.markdowninlinecode")
+	inlineCode := rc.Mattermost.MarkdownInlineCode
 	if useUnicode {
 		prefixChar = messageAttachmentCharUnicode
 		spaceChar = messageAttachmentSpaceUnicode

--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -716,11 +716,11 @@ func (m *Mattermost) wsActionPostSkip(rmsg *model.WebSocketEvent) bool {
 
 	rc := m.cfg.Current()
 
-	disableMarkdown := rc.Mattermost.DisableMarkdown
-	disableEmoji := rc.Mattermost.DisableEmoji
-	useUnicode := rc.Mattermost.Unicode
+	disableMarkdown := rc.Mattermost.Formatter.DisableMarkdown
+	disableEmoji := rc.Mattermost.Formatter.DisableEmoji
+	useUnicode := rc.Mattermost.Formatter.Unicode
 	blockquoteChar := blockquoteCharNonUnicode
-	inlineCode := rc.Mattermost.MarkdownInlineCode
+	inlineCode := rc.Mattermost.Formatter.MarkdownInlineCode
 	if useUnicode {
 		blockquoteChar = blockquoteCharUnicode
 	}
@@ -854,11 +854,11 @@ func (m *Mattermost) getParentReplyMsg(parentID string, preFetchedPost *model.Po
 
 	rc := m.cfg.Current()
 
-	disableMarkdown := rc.Mattermost.DisableMarkdown
-	disableEmoji := rc.Mattermost.DisableEmoji
-	useUnicode := rc.Mattermost.Unicode
+	disableMarkdown := rc.Mattermost.Formatter.DisableMarkdown
+	disableEmoji := rc.Mattermost.Formatter.DisableEmoji
+	useUnicode := rc.Mattermost.Formatter.Unicode
 	blockquoteChar := blockquoteCharNonUnicode
-	inlineCode := rc.Mattermost.MarkdownInlineCode
+	inlineCode := rc.Mattermost.Formatter.MarkdownInlineCode
 	if useUnicode {
 		blockquoteChar = blockquoteCharUnicode
 	}
@@ -948,7 +948,7 @@ func (m *Mattermost) handleWsActionPost(rmsg *model.WebSocketEvent) {
 
 	rc := m.cfg.Current()
 
-	useUnicode := rc.Mattermost.Unicode
+	useUnicode := rc.Mattermost.Formatter.Unicode
 
 	var sbSuffix strings.Builder
 	if !rc.Mattermost.HideReplies && data.RootId != "" {
@@ -1503,7 +1503,7 @@ func (m *Mattermost) handleReactionEvent(rmsg *model.WebSocketEvent) {
 			parentID = parentPost.RootId
 		}
 		if !rc.Mattermost.HideReplies {
-			replyMsg, err := m.getParentReplyMsg(reaction.PostId, parentPost, rc.Mattermost.ShortenRepliesTo, "@", rc.Mattermost.Unicode)
+			replyMsg, err := m.getParentReplyMsg(reaction.PostId, parentPost, rc.Mattermost.ShortenRepliesTo, "@", rc.Mattermost.Formatter.Unicode)
 			if err == nil {
 				sbSuffix.WriteString(replyMsg)
 			}
@@ -1726,16 +1726,16 @@ const blockQuoteCharDefault = ">"
 func (m *Mattermost) parseMessageAttachments(attachments []*model.SlackAttachment, useFallback bool) string {
 	rc := m.cfg.Current()
 
-	useUnicode := rc.Mattermost.Unicode
-	syntaxHighlighting := rc.Mattermost.SyntaxHighlighting
-	codeBlockPrefix := rc.Mattermost.CodeBlockPrefix
-	disableMarkdown := rc.Mattermost.DisableMarkdown
-	disableEmoji := rc.Mattermost.DisableEmoji
+	useUnicode := rc.Mattermost.Formatter.Unicode
+	syntaxHighlighting := rc.Mattermost.Formatter.SyntaxHighlighting
+	codeBlockPrefix := rc.Mattermost.Formatter.CodeBlockPrefix
+	disableMarkdown := rc.Mattermost.Formatter.DisableMarkdown
+	disableEmoji := rc.Mattermost.Formatter.DisableEmoji
 
 	prefixChar := messageAttachmentCharNonUnicode
 	spaceChar := messageAttachmentSpaceNonUnicode
 	blockquoteChar := blockquoteCharNonUnicode
-	inlineCode := rc.Mattermost.MarkdownInlineCode
+	inlineCode := rc.Mattermost.Formatter.MarkdownInlineCode
 	if useUnicode {
 		prefixChar = messageAttachmentCharUnicode
 		spaceChar = messageAttachmentSpaceUnicode
@@ -1990,4 +1990,16 @@ func (m *Mattermost) GetLastSentMsgs() []string {
 	}
 
 	return data
+}
+
+func (m *Mattermost) Config() any {
+	return &m.cfg.Current().Mattermost
+}
+
+func (m *Mattermost) BridgeConfig() *config.BridgeConfig {
+	return &m.cfg.Current().Mattermost.Bridge
+}
+
+func (m *Mattermost) FormatterConfig() *config.FormatterConfig {
+	return &m.cfg.Current().Mattermost.Formatter
 }

--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -43,6 +43,8 @@ func New(cfg *config.Config, cred bridge.Credentials, eventChan chan *bridge.Eve
 
 	var err error
 
+	rc := cfg.Current()
+
 	ourlog := logrus.New()
 	ourlog.SetFormatter(&prefixed.TextFormatter{
 		PrefixPadding: 13,
@@ -50,9 +52,6 @@ func New(cfg *config.Config, cred bridge.Credentials, eventChan chan *bridge.Eve
 		FullTimestamp: true,
 	})
 	logger = ourlog.WithFields(logrus.Fields{"prefix": "bridge/slack"})
-
-	rc := cfg.Current()
-
 	if rc.Debug {
 		ourlog.SetLevel(logrus.DebugLevel)
 	}

--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -8,11 +8,11 @@ import (
 	"time"
 
 	"github.com/42wim/matterircd/bridge"
+	"github.com/42wim/matterircd/config"
 	"github.com/davecgh/go-spew/spew"
 	prefixed "github.com/matterbridge/logrus-prefixed-formatter"
 	"github.com/sirupsen/logrus"
 	"github.com/slack-go/slack"
-	"github.com/spf13/viper"
 )
 
 type Slack struct {
@@ -27,17 +27,18 @@ type Slack struct {
 	onConnect    func()
 	msgLast      map[string]string
 	sync.RWMutex
-	v *viper.Viper
+
+	cfg *config.Config
 }
 
 var logger *logrus.Entry
 
-func New(v *viper.Viper, cred bridge.Credentials, eventChan chan *bridge.Event, onConnect func()) (bridge.Bridger, error) {
+func New(cfg *config.Config, cred bridge.Credentials, eventChan chan *bridge.Event, onConnect func()) (bridge.Bridger, error) {
 	s := &Slack{
 		credentials: cred,
 		eventChan:   eventChan,
 		onConnect:   onConnect,
-		v:           v,
+		cfg:         cfg,
 	}
 
 	var err error
@@ -49,11 +50,14 @@ func New(v *viper.Viper, cred bridge.Credentials, eventChan chan *bridge.Event, 
 		FullTimestamp: true,
 	})
 	logger = ourlog.WithFields(logrus.Fields{"prefix": "bridge/slack"})
-	if v.GetBool("debug") {
+
+	rc := cfg.Current()
+
+	if rc.Debug {
 		ourlog.SetLevel(logrus.DebugLevel)
 	}
 
-	if v.GetBool("trace") {
+	if rc.Trace {
 		ourlog.SetLevel(logrus.TraceLevel)
 	}
 
@@ -449,11 +453,12 @@ func (s *Slack) GetChannelID(name, teamID string) string {
 }
 
 func (s *Slack) allowedLogin() error {
+	rc := s.cfg.Current()
 	// we only know which server we are connecting to when we actually are connected.
 	// disconnect if we're not allowed
-	if len(s.v.GetStringSlice("slack.restrict")) > 0 {
+	if len(rc.Slack.Restrict) > 0 {
 		ok := false
-		for _, domain := range s.v.GetStringSlice("slack.restrict") {
+		for _, domain := range rc.Slack.Restrict {
 			if domain == s.sinfo.Team.Domain {
 				ok = true
 				break
@@ -466,9 +471,9 @@ func (s *Slack) allowedLogin() error {
 	}
 	// we only know which user we are when we actually are connected.
 	// disconnect if we're not allowed
-	if len(s.v.GetStringSlice("slack.DenyUsers")) > 0 {
+	if len(rc.Slack.DenyUsers) > 0 {
 		ok := false
-		for _, user := range s.v.GetStringSlice("slack.DenyUsers") {
+		for _, user := range rc.Slack.DenyUsers {
 			if user == s.sinfo.User.Name {
 				ok = true
 				break
@@ -891,8 +896,10 @@ func (s *Slack) createUser(slackuser *slack.User) *bridge.UserInfo {
 		return &bridge.UserInfo{}
 	}
 
+	rc := s.cfg.Current()
+
 	nick := slackuser.Name
-	if (s.v.GetBool("slack.PreferNickname") || s.v.GetBool("slack.UseDisplayName")) && isValidNick(slackuser.Profile.DisplayName) {
+	if (rc.Slack.PreferNickname || rc.Slack.UseDisplayName) && isValidNick(slackuser.Profile.DisplayName) {
 		nick = slackuser.Profile.DisplayName
 	}
 

--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -455,9 +455,9 @@ func (s *Slack) allowedLogin() error {
 	rc := s.cfg.Current()
 	// we only know which server we are connecting to when we actually are connected.
 	// disconnect if we're not allowed
-	if len(rc.Slack.Restrict) > 0 {
+	if len(rc.Slack.Bridge.Restrict) > 0 {
 		ok := false
-		for _, domain := range rc.Slack.Restrict {
+		for _, domain := range rc.Slack.Bridge.Restrict {
 			if domain == s.sinfo.Team.Domain {
 				ok = true
 				break
@@ -1002,4 +1002,16 @@ func (s *Slack) RemoveReaction(msgID, emoji string) error {
 
 func (s *Slack) GetLastSentMsgs() []string {
 	return []string{}
+}
+
+func (s *Slack) Config() any {
+	return &s.cfg.Current().Slack
+}
+
+func (s *Slack) BridgeConfig() *config.BridgeConfig {
+	return &s.cfg.Current().Slack.Bridge
+}
+
+func (s *Slack) FormatterConfig() *config.FormatterConfig {
+	return &s.cfg.Current().Slack.Formatter
 }

--- a/config/config.go
+++ b/config/config.go
@@ -4,14 +4,160 @@ import (
 	"fmt"
 	"runtime"
 	"strings"
+	"sync/atomic"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
 
 var Logger *logrus.Entry
 
-func LoadConfig(cfgfile string) (*viper.Viper, error) {
+type Config struct {
+	current atomic.Pointer[RuntimeConfig]
+
+	v *viper.Viper
+}
+
+// RuntimeConfig is immutable.
+//
+// A new RuntimeConfig is constructed whenever the configuration is
+// reloaded and atomically published. Callers must never modify it.
+type RuntimeConfig struct {
+	GlobalConfig
+
+	Mattermost MattermostConfig
+	Slack      SlackConfig
+	Mastodon   MastodonConfig
+}
+
+type GlobalConfig struct {
+	Bind string
+
+	Debug bool
+	Trace bool
+	Gops  bool
+
+	TLSBind string
+	TLSDir  string
+	TLSKey  string
+	TLSCert string
+
+	HandshakeTimeout int
+	ClientTimeout    int
+
+	PasteBufferTimeout int
+}
+
+type MattermostConfig struct {
+	DefaultServer string
+	DefaultTeam   string
+
+	Insecure bool
+
+	DisableMarkdown bool
+	DisableEmoji    bool
+
+	Unicode bool
+
+	PrefixContext bool
+	SuffixContext bool
+
+	ShowMentions bool
+}
+
+type SlackConfig struct {
+	Restrict []string
+}
+
+type MastodonConfig struct {
+	Server string
+
+	ClientID     string
+	ClientSecret string
+	AccessToken  string
+}
+
+func (c *Config) buildRuntimeCfg() *RuntimeConfig {
+	return &RuntimeConfig{
+		GlobalConfig: GlobalConfig{
+			Bind: c.v.GetString("bind"),
+
+			Debug: c.v.GetBool("debug"),
+			Trace: c.v.GetBool("trace"),
+			Gops:  c.v.GetBool("gops"),
+
+			TLSBind: c.v.GetString("tlsbind"),
+			TLSDir:  c.v.GetString("tlsdir"),
+			TLSKey:  c.v.GetString("tlskey"),
+			TLSCert: c.v.GetString("tlscert"),
+
+			HandshakeTimeout: c.v.GetInt("HandshakeTimeout"),
+			ClientTimeout:    c.v.GetInt("ClientTimeout"),
+
+			PasteBufferTimeout: c.v.GetInt("PasteBufferTimeout"),
+		},
+
+		Mattermost: MattermostConfig{
+			DefaultServer: c.v.GetString("mattermost.DefaultServer"),
+			DefaultTeam:   c.v.GetString("mattermost.DefaultTeam"),
+
+			Insecure: c.v.GetBool("mattermost.Insecure"),
+
+			DisableMarkdown: c.v.GetBool("mattermost.DisableMarkdown"),
+			DisableEmoji:    c.v.GetBool("mattermost.DisableEmoji"),
+			Unicode:         c.v.GetBool("mattermost.Unicode"),
+
+			PrefixContext: c.v.GetBool("mattermost.PrefixContext"),
+			SuffixContext: c.v.GetBool("mattermost.SuffixContext"),
+
+			ShowMentions: c.v.GetBool("mattermost.ShowMentions"),
+		},
+
+		Slack: SlackConfig{
+			Restrict: append([]string(nil),
+				c.v.GetStringSlice("slack.Restrict")...),
+		},
+
+		Mastodon: MastodonConfig{
+			Server: c.v.GetString("mastodon.server"),
+
+			ClientID:     c.v.GetString("mastodon.clientid"),
+			ClientSecret: c.v.GetString("mastodon.clientsecret"),
+			AccessToken:  c.v.GetString("mastodon.accesstoken"),
+		},
+	}
+}
+
+func (c *Config) reload() error {
+	if err := c.v.ReadInConfig(); err != nil {
+		return err
+	}
+
+	runtimeCfg := c.buildRuntimeCfg()
+
+	if err := validate(runtimeCfg); err != nil {
+		return err
+	}
+
+	c.current.Store(runtimeCfg)
+
+	if Logger != nil {
+		Logger.Info("configuration reloaded")
+	}
+
+	return nil
+}
+
+func validate(runtimeCfg *RuntimeConfig) error {
+	return nil
+}
+
+func (c *Config) Current() *RuntimeConfig {
+	return c.current.Load()
+}
+
+func Load(cfgfile string) (*Config, error) {
 	v := viper.New()
 	v.SetConfigFile(cfgfile)
 
@@ -20,14 +166,26 @@ func LoadConfig(cfgfile string) (*viper.Viper, error) {
 	// use environment variables
 	v.AutomaticEnv()
 
-	if err := v.ReadInConfig(); err != nil {
-		return nil, fmt.Errorf("error reading config file %s", err)
+	c := &Config{
+		v: v,
+	}
+
+	if err := c.reload(); err != nil {
+		return nil, fmt.Errorf("error reading config file: %w", err)
 	}
 
 	// reload config on file changes
 	if runtime.GOOS != "illumos" {
+		v.OnConfigChange(func(e fsnotify.Event) {
+			if err := c.reload(); err != nil {
+				if Logger != nil {
+					Logger.Errorf("config reload failed: %v", err)
+				}
+			}
+		})
+
 		v.WatchConfig()
 	}
 
-	return v, nil
+	return c, nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -326,21 +326,6 @@ func (c *Config) Current() *RuntimeConfig {
 	return c.current.Load()
 }
 
-func (c *Config) ProtocolConfig(protocol string) any {
-	rc := c.Current()
-
-	switch protocol {
-	case "mattermost":
-		return &rc.Mattermost
-	case "slack":
-		return &rc.Slack
-	case "mastodon":
-		return &rc.Mastodon
-	default:
-		return nil
-	}
-}
-
 func (c *Config) Mattermost() *MattermostConfig {
 	return &c.Current().Mattermost
 }

--- a/config/config.go
+++ b/config/config.go
@@ -74,7 +74,16 @@ type MattermostConfig struct {
 }
 
 type SlackConfig struct {
-	Restrict []string
+	DenyUsers      []string
+	JoinDM         bool
+	Restrict       []string
+	UseDisplayName bool
+	PreferNickname bool
+	JoinOnly       []string
+	JoinExclude    []string
+	JoinInclude    []string
+	ShowOnlyJoined bool
+	PrefixContext  bool
 }
 
 type MastodonConfig struct {
@@ -124,8 +133,18 @@ func (c *Config) buildRuntimeCfg() *RuntimeConfig {
 		},
 
 		Slack: SlackConfig{
-			Restrict: append([]string(nil),
-				c.v.GetStringSlice("slack.Restrict")...),
+			DenyUsers:      append([]string(nil), c.v.GetStringSlice("slack.DenyUsers")...),
+			JoinDM:         c.v.GetBool("slack.JoinDM"),
+			Restrict:       append([]string(nil), c.v.GetStringSlice("slack.Restrict")...),
+			UseDisplayName: c.v.GetBool("slack.UseDisplayName"),
+			PreferNickname: c.v.GetBool("slack.PreferNickname"),
+
+			JoinOnly:    append([]string(nil), c.v.GetStringSlice("slack.JoinOnly")...),
+			JoinExclude: append([]string(nil), c.v.GetStringSlice("slack.JoinExclude")...),
+			JoinInclude: append([]string(nil), c.v.GetStringSlice("slack.JoinInclude")...),
+
+			ShowOnlyJoined: c.v.GetBool("slack.ShowOnlyJoined"),
+			PrefixContext:  c.v.GetBool("slack.PrefixContext"),
 		},
 
 		Mastodon: MastodonConfig{

--- a/config/config.go
+++ b/config/config.go
@@ -152,9 +152,9 @@ func (c *Config) buildRuntimeCfg() *RuntimeConfig {
 	mmBridge := BridgeConfig{
 		Restrict: append([]string(nil), c.v.GetStringSlice("mattermost.Restrict")...),
 
-		JoinOnly:    append([]string(nil), c.v.GetStringSlice("mattermost.joinonly")...),
-		JoinExclude: append([]string(nil), c.v.GetStringSlice("mattermost.joininclude")...),
-		JoinInclude: append([]string(nil), c.v.GetStringSlice("mattermost.joinexclude")...),
+		JoinOnly:    append([]string(nil), c.v.GetStringSlice("mattermost.JoinOnly")...),
+		JoinExclude: append([]string(nil), c.v.GetStringSlice("mattermost.JoinExclude")...),
+		JoinInclude: append([]string(nil), c.v.GetStringSlice("mattermost.JoinInclude")...),
 
 		ShowJoinPart:   c.v.GetBool("mattermost.ShowJoinPart"),
 		ShowOnlyJoined: c.v.GetBool("mattermost.ShowOnlyJoined"),
@@ -162,8 +162,8 @@ func (c *Config) buildRuntimeCfg() *RuntimeConfig {
 
 		PrefixContext:    c.v.GetBool("mattermost.PrefixContext"),
 		SuffixContext:    c.v.GetBool("mattermost.SuffixContext"),
-		ThreadContext:    c.v.GetString("mattermost.ThreadContext"),
 		ShowContextMulti: c.v.GetBool("mattermost.ShowContextMulti"),
+		ThreadContext:    c.v.GetString("mattermost.ThreadContext"),
 	}
 	slBridge := BridgeConfig{
 		Restrict: append([]string(nil), c.v.GetStringSlice("slack.Restrict")...),
@@ -178,8 +178,8 @@ func (c *Config) buildRuntimeCfg() *RuntimeConfig {
 
 		PrefixContext:    c.v.GetBool("slack.PrefixContext"),
 		SuffixContext:    c.v.GetBool("slack.SuffixContext"),
-		ThreadContext:    c.v.GetString("slack.ThreadContext"),
 		ShowContextMulti: c.v.GetBool("slack.ShowContextMulti"),
+		ThreadContext:    c.v.GetString("slack.ThreadContext"),
 	}
 	mdBridge := BridgeConfig{
 		Restrict: append([]string(nil), c.v.GetStringSlice("mastodon.Restrict")...),
@@ -194,8 +194,8 @@ func (c *Config) buildRuntimeCfg() *RuntimeConfig {
 
 		PrefixContext:    c.v.GetBool("mastodon.PrefixContext"),
 		SuffixContext:    c.v.GetBool("mastodon.SuffixContext"),
-		ThreadContext:    c.v.GetString("mastodon.ThreadContext"),
 		ShowContextMulti: c.v.GetBool("mastodon.ShowContextMulti"),
+		ThreadContext:    c.v.GetString("mastodon.ThreadContext"),
 	}
 
 	mmFormatter := FormatterConfig{
@@ -206,9 +206,9 @@ func (c *Config) buildRuntimeCfg() *RuntimeConfig {
 		MarkdownBlockQuoteChar:    c.v.GetString("mattermost.MarkdownBlockQuoteChar"),
 		MarkdownInlineCode:        c.v.GetString("mattermost.MarkdownInlineCode"),
 
-		SyntaxHighlighting:     c.v.GetString("mattermost.SyntaxHighlighting"),
 		DisableCodeBlockPrefix: c.v.GetBool("mattermost.DisableCodeBlockPrefix"),
 		CodeBlockPrefix:        c.v.GetString("mattermost.CodeBlockPrefix"),
+		SyntaxHighlighting:     c.v.GetString("mattermost.SyntaxHighlighting"),
 
 		Unicode: c.v.GetBool("mattermost.Unicode"),
 	}
@@ -220,9 +220,9 @@ func (c *Config) buildRuntimeCfg() *RuntimeConfig {
 		MarkdownBlockQuoteChar:    c.v.GetString("slack.MarkdownBlockQuoteChar"),
 		MarkdownInlineCode:        c.v.GetString("slack.MarkdownInlineCode"),
 
-		SyntaxHighlighting:     c.v.GetString("slack.SyntaxHighlighting"),
 		DisableCodeBlockPrefix: c.v.GetBool("slack.DisableCodeBlockPrefix"),
 		CodeBlockPrefix:        c.v.GetString("slack.CodeBlockPrefix"),
+		SyntaxHighlighting:     c.v.GetString("slack.SyntaxHighlighting"),
 
 		Unicode: c.v.GetBool("slack.Unicode"),
 	}
@@ -234,9 +234,9 @@ func (c *Config) buildRuntimeCfg() *RuntimeConfig {
 		MarkdownBlockQuoteChar:    c.v.GetString("mastodon.MarkdownBlockQuoteChar"),
 		MarkdownInlineCode:        c.v.GetString("mastodon.MarkdownInlineCode"),
 
-		SyntaxHighlighting:     c.v.GetString("mastodon.SyntaxHighlighting"),
 		DisableCodeBlockPrefix: c.v.GetBool("mastodon.DisableCodeBlockPrefix"),
 		CodeBlockPrefix:        c.v.GetString("mastodon.CodeBlockPrefix"),
+		SyntaxHighlighting:     c.v.GetString("mastodon.SyntaxHighlighting"),
 
 		Unicode: c.v.GetBool("mastodon.Unicode"),
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -54,27 +54,48 @@ type GlobalConfig struct {
 	PasteBufferTimeout int
 }
 
+type BridgeConfig struct {
+	Restrict []string
+
+	JoinOnly    bool
+	JoinExclude []string
+	JoinInclude []string
+
+	ShowJoinPart   bool
+	ShowOnlyJoined bool
+}
+
+type FormatterConfig struct {
+	DisableEmoji              bool
+
+	DisableMarkdown           bool
+	DisableMarkdownBlockQuote bool
+	MarkdownBlockQuoteChar    string
+	MarkdownInlineCode        string
+
+	SyntaxHighlighting     string
+	DisableCodeBlockPrefix bool
+	CodeBlockPrefix        string
+
+	Unicode            bool
+}
+
 type MattermostConfig struct {
+	Bridge    BridgeConfig
+	Formatter FormatterConfig
+
 	DefaultServer string
 	DefaultTeam   string
 
 	Insecure           bool
 	IgnoreServerVersion bool
 
-	JoinOnly    []string
-	JoinExclude []string
-	JoinInclude []string
-
 	CollapseScrollback bool
-	ShowOnlyJoined     bool
 	PartFake           bool
-
-	Restrict []string
 
 	SkipTLSVerify bool
 
 	PrefixMainTeam bool
-	DisableAutoView bool
 
 	ForceAntiIdle   bool
 	AntiIdleChannel string
@@ -85,24 +106,16 @@ type MattermostConfig struct {
 	HideReplies      bool
 	ShortenRepliesTo int
 
-	Unicode bool
 
 	HideReactions    bool
 	ShowOwnReactions bool
 
-	DisableEmoji bool
-
-	DisableMarkdown           bool
-	DisableMarkdownBlockQuote bool
-	MarkdownBlockQuoteChar    string
-	MarkdownInlineCode        string
-
 	JoinDM bool
 
-	PrefixContext bool
-	SuffixContext bool
-
-	ThreadContext   string
+	// Threading / context related
+	PrefixContext    bool
+	SuffixContext    bool
+	ThreadContext    string
 	ShowContextMulti bool
 
 	ShowMentions bool
@@ -110,27 +123,24 @@ type MattermostConfig struct {
 	DisableDefaultMentions bool
 	DisableShowOwnModified bool
 
-	SyntaxHighlighting     string
-	DisableCodeBlockPrefix bool
-	CodeBlockPrefix        string
-
+	DisableAutoView    bool
 	LastViewedSaveFile string
 }
 
 type SlackConfig struct {
+	Bridge    BridgeConfig
+	Formatter FormatterConfig
+
 	DenyUsers      []string
 	JoinDM         bool
-	Restrict       []string
 	UseDisplayName bool
 	PreferNickname bool
-	JoinOnly       []string
-	JoinExclude    []string
-	JoinInclude    []string
-	ShowOnlyJoined bool
-	PrefixContext  bool
 }
 
 type MastodonConfig struct {
+	Bridge    BridgeConfig
+	Formatter FormatterConfig
+
 	Server string
 
 	ClientID     string
@@ -139,6 +149,80 @@ type MastodonConfig struct {
 }
 
 func (c *Config) buildRuntimeCfg() *RuntimeConfig {
+	mmBridge := BridgeConfig{
+		Restrict:      append([]string(nil), c.v.GetStringSlice("mattermost.Restrict")...),
+
+		JoinOnly:    c.v.GetBool("mattermost.JoinOnly"),
+		JoinExclude: c.v.GetStringSlice("mattermost.JoinExclude"),
+		JoinInclude: c.v.GetStringSlice("mattermost.JoinInclude"),
+
+		ShowJoinPart:   c.v.GetBool("mattermost.ShowJoinPart"),
+		ShowOnlyJoined: c.v.GetBool("mattermost.ShowOnlyJoined"),
+	}
+	slBridge := BridgeConfig{
+		Restrict:      append([]string(nil), c.v.GetStringSlice("slack.Restrict")...),
+
+		JoinOnly:    c.v.GetBool("slack.JoinOnly"),
+		JoinExclude: c.v.GetStringSlice("slack.JoinExclude"),
+		JoinInclude: c.v.GetStringSlice("slack.JoinInclude"),
+
+		ShowJoinPart:   c.v.GetBool("slack.ShowJoinPart"),
+		ShowOnlyJoined: c.v.GetBool("slack.ShowOnlyJoined"),
+	}
+	mdBridge := BridgeConfig{
+		Restrict:      append([]string(nil), c.v.GetStringSlice("mastodon.Restrict")...),
+
+		JoinOnly:    c.v.GetBool("mastodon.JoinOnly"),
+		JoinExclude: c.v.GetStringSlice("mastodon.JoinExclude"),
+		JoinInclude: c.v.GetStringSlice("mastodon.JoinInclude"),
+
+		ShowJoinPart:   c.v.GetBool("mastodon.ShowJoinPart"),
+		ShowOnlyJoined: c.v.GetBool("mastodon.ShowOnlyJoined"),
+	}
+
+	mmFormatter := FormatterConfig{
+		DisableEmoji: c.v.GetBool("mattermost.DisableEmoji"),
+
+		DisableMarkdown:           c.v.GetBool("mattermost.DisableMarkdown"),
+		DisableMarkdownBlockQuote: c.v.GetBool("mattermost.DisableMarkdownBlockQuote"),
+		MarkdownBlockQuoteChar:    c.v.GetString("mattermost.MarkdownBlockQuoteChar"),
+		MarkdownInlineCode:        c.v.GetString("mattermost.MarkdownInlineCode"),
+
+		SyntaxHighlighting:     c.v.GetString("mattermost.SyntaxHighlighting"),
+		DisableCodeBlockPrefix: c.v.GetBool("mattermost.DisableCodeBlockPrefix"),
+		CodeBlockPrefix:        c.v.GetString("mattermost.CodeBlockPrefix"),
+
+		Unicode: c.v.GetBool("mattermost.Unicode"),
+	}
+	slFormatter := FormatterConfig{
+		DisableEmoji: c.v.GetBool("slack.DisableEmoji"),
+
+		DisableMarkdown:           c.v.GetBool("slack.DisableMarkdown"),
+		DisableMarkdownBlockQuote: c.v.GetBool("slack.DisableMarkdownBlockQuote"),
+		MarkdownBlockQuoteChar:    c.v.GetString("slack.MarkdownBlockQuoteChar"),
+		MarkdownInlineCode:        c.v.GetString("slack.MarkdownInlineCode"),
+
+		SyntaxHighlighting:     c.v.GetString("slack.SyntaxHighlighting"),
+		DisableCodeBlockPrefix: c.v.GetBool("slack.DisableCodeBlockPrefix"),
+		CodeBlockPrefix:        c.v.GetString("slack.CodeBlockPrefix"),
+
+		Unicode: c.v.GetBool("slack.Unicode"),
+	}
+	mdFormatter := FormatterConfig{
+		DisableEmoji: c.v.GetBool("mastodon.DisableEmoji"),
+
+		DisableMarkdown:           c.v.GetBool("mastodon.DisableMarkdown"),
+		DisableMarkdownBlockQuote: c.v.GetBool("mastodon.DisableMarkdownBlockQuote"),
+		MarkdownBlockQuoteChar:    c.v.GetString("mastodon.MarkdownBlockQuoteChar"),
+		MarkdownInlineCode:        c.v.GetString("mastodon.MarkdownInlineCode"),
+
+		SyntaxHighlighting:     c.v.GetString("mastodon.SyntaxHighlighting"),
+		DisableCodeBlockPrefix: c.v.GetBool("mastodon.DisableCodeBlockPrefix"),
+		CodeBlockPrefix:        c.v.GetString("mastodon.CodeBlockPrefix"),
+
+		Unicode: c.v.GetBool("mastodon.Unicode"),
+	}
+
 	return &RuntimeConfig{
 		GlobalConfig: GlobalConfig{
 			Bind: c.v.GetString("bind"),
@@ -159,28 +243,24 @@ func (c *Config) buildRuntimeCfg() *RuntimeConfig {
 		},
 
 		Mattermost: MattermostConfig{
-			Restrict:      append([]string(nil), c.v.GetStringSlice("mattermost.Restrict")...),
+			Bridge:    mmBridge,
+			Formatter: mmFormatter,
+
 			DefaultServer: c.v.GetString("mattermost.DefaultServer"),
 			DefaultTeam:   c.v.GetString("mattermost.DefaultTeam"),
 
 			Insecure:            c.v.GetBool("mattermost.Insecure"),
 			IgnoreServerVersion: c.v.GetBool("mattermost.IgnoreServerVersion"),
 
-			JoinOnly: append([]string(nil), c.v.GetStringSlice("mattermost.JoinOnly")...),
-			JoinExclude: append([]string(nil), c.v.GetStringSlice("mattermost.JoinExclude")...),
-			JoinInclude: append([]string(nil), c.v.GetStringSlice("mattermost.JoinInclude")...),
-
 			CollapseScrollback: c.v.GetBool("mattermost.CollapseScrollback"),
-			ShowOnlyJoined:     c.v.GetBool("mattermost.ShowOnlyJoined"),
 			PartFake:           c.v.GetBool("mattermost.PartFake"),
 
 			SkipTLSVerify: c.v.GetBool("mattermost.SkipTLSVerify"),
 
 			PrefixMainTeam: c.v.GetBool("mattermost.PrefixMainTeam"),
-			DisableAutoView: c.v.GetBool("mattermost.DisableAutoView"),
 
-			ForceAntiIdle:   c.v.GetBool("mattermost.ForceAntiIdle"),
-			AntiIdleChannel: c.v.GetString("mattermost.AntiIdleChannel"),
+			ForceAntiIdle:    c.v.GetBool("mattermost.ForceAntiIdle"),
+			AntiIdleChannel:  c.v.GetString("mattermost.AntiIdleChannel"),
 			AntiIdleInterval: c.v.GetInt("mattermost.AntiIdleInterval"),
 
 			PreferNickname: c.v.GetBool("mattermost.PreferNickname"),
@@ -188,23 +268,13 @@ func (c *Config) buildRuntimeCfg() *RuntimeConfig {
 			HideReplies:      c.v.GetBool("mattermost.HideReplies"),
 			ShortenRepliesTo: c.v.GetInt("mattermost.ShortenRepliesTo"),
 
-			Unicode: c.v.GetBool("mattermost.Unicode"),
-
 			HideReactions:    c.v.GetBool("mattermost.HideReactions"),
 			ShowOwnReactions: c.v.GetBool("mattermost.ShowOwnReactions"),
 
-			DisableEmoji: c.v.GetBool("mattermost.DisableEmoji"),
-
-			DisableMarkdown:           c.v.GetBool("mattermost.DisableMarkdown"),
-			DisableMarkdownBlockQuote: c.v.GetBool("mattermost.DisableMarkdownBlockQuote"),
-			MarkdownBlockQuoteChar:    c.v.GetString("mattermost.MarkdownBlockQuoteChar"),
-			MarkdownInlineCode:        c.v.GetString("mattermost.MarkdownInlineCode"),
-
 			JoinDM: c.v.GetBool("mattermost.JoinDM"),
 
-			PrefixContext: c.v.GetBool("mattermost.PrefixContext"),
-			SuffixContext: c.v.GetBool("mattermost.SuffixContext"),
-
+			PrefixContext:    c.v.GetBool("mattermost.PrefixContext"),
+			SuffixContext:    c.v.GetBool("mattermost.SuffixContext"),
 			ThreadContext:    c.v.GetString("mattermost.ThreadContext"),
 			ShowContextMulti: c.v.GetBool("mattermost.ShowContextMulti"),
 
@@ -213,29 +283,24 @@ func (c *Config) buildRuntimeCfg() *RuntimeConfig {
 			DisableDefaultMentions: c.v.GetBool("mattermost.DisableDefaultMentions"),
 			DisableShowOwnModified: c.v.GetBool("mattermost.DisableShowOwnModified"),
 
-			SyntaxHighlighting:     c.v.GetString("mattermost.SyntaxHighlighting"),
-			DisableCodeBlockPrefix: c.v.GetBool("mattermost.DisableCodeBlockPrefix"),
-			CodeBlockPrefix:        c.v.GetString("mattermost.CodeBlockPrefix"),
-
+			DisableAutoView: c.v.GetBool("mattermost.DisableAutoView"),
 			LastViewedSaveFile: c.v.GetString("mattermost.LastViewedSaveFile"),
 		},
 
 		Slack: SlackConfig{
-			Restrict:       append([]string(nil), c.v.GetStringSlice("slack.Restrict")...),
+			Bridge:    slBridge,
+			Formatter: slFormatter,
+
 			DenyUsers:      append([]string(nil), c.v.GetStringSlice("slack.DenyUsers")...),
 			JoinDM:         c.v.GetBool("slack.JoinDM"),
 			UseDisplayName: c.v.GetBool("slack.UseDisplayName"),
 			PreferNickname: c.v.GetBool("slack.PreferNickname"),
-
-			JoinOnly:    append([]string(nil), c.v.GetStringSlice("slack.JoinOnly")...),
-			JoinExclude: append([]string(nil), c.v.GetStringSlice("slack.JoinExclude")...),
-			JoinInclude: append([]string(nil), c.v.GetStringSlice("slack.JoinInclude")...),
-
-			ShowOnlyJoined: c.v.GetBool("slack.ShowOnlyJoined"),
-			PrefixContext:  c.v.GetBool("slack.PrefixContext"),
 		},
 
 		Mastodon: MastodonConfig{
+			Bridge:    mdBridge,
+			Formatter: mdFormatter,
+
 			Server: c.v.GetString("mastodon.server"),
 
 			ClientID:     c.v.GetString("mastodon.clientid"),
@@ -247,6 +312,21 @@ func (c *Config) buildRuntimeCfg() *RuntimeConfig {
 
 func (c *Config) Current() *RuntimeConfig {
 	return c.current.Load()
+}
+
+func (c *Config) CurrentProtocol(protocol string) any {
+	rc := c.Current()
+
+	switch protocol {
+	case "mattermost":
+		return &rc.Mattermost
+	case "slack":
+		return &rc.Slack
+	case "mastodon":
+		return &rc.Mastodon
+	default:
+		return nil
+	}
 }
 
 func Load(cfgfile string, flags *pflag.FlagSet) (*Config, error) {

--- a/config/config.go
+++ b/config/config.go
@@ -39,9 +39,9 @@ type RuntimeConfig struct {
 type GlobalConfig struct {
 	Bind string
 
-	Debug   bool
-	Trace   bool
-	Gops    bool
+	Debug bool
+	Trace bool
+	Gops  bool
 
 	TLSBind string
 	TLSDir  string
@@ -73,7 +73,7 @@ type BridgeConfig struct {
 }
 
 type FormatterConfig struct {
-	DisableEmoji              bool
+	DisableEmoji bool
 
 	DisableMarkdown           bool
 	DisableMarkdownBlockQuote bool
@@ -84,7 +84,7 @@ type FormatterConfig struct {
 	DisableCodeBlockPrefix bool
 	CodeBlockPrefix        string
 
-	Unicode            bool
+	Unicode bool
 }
 
 type MattermostConfig struct {
@@ -94,7 +94,7 @@ type MattermostConfig struct {
 	DefaultServer string
 	DefaultTeam   string
 
-	Insecure           bool
+	Insecure            bool
 	IgnoreServerVersion bool
 
 	CollapseScrollback bool
@@ -103,15 +103,14 @@ type MattermostConfig struct {
 
 	PrefixMainTeam bool
 
-	ForceAntiIdle   bool
-	AntiIdleChannel string
+	ForceAntiIdle    bool
+	AntiIdleChannel  string
 	AntiIdleInterval int
 
 	PreferNickname bool
 
 	HideReplies      bool
 	ShortenRepliesTo int
-
 
 	HideReactions    bool
 	ShowOwnReactions bool
@@ -148,9 +147,10 @@ type MastodonConfig struct {
 	AccessToken  string
 }
 
+//nolint:funlen
 func (c *Config) buildRuntimeCfg() *RuntimeConfig {
 	mmBridge := BridgeConfig{
-		Restrict:      append([]string(nil), c.v.GetStringSlice("mattermost.Restrict")...),
+		Restrict: append([]string(nil), c.v.GetStringSlice("mattermost.Restrict")...),
 
 		JoinOnly:    c.v.GetStringSlice("mattermost.JoinOnly"),
 		JoinExclude: c.v.GetStringSlice("mattermost.JoinExclude"),
@@ -164,10 +164,9 @@ func (c *Config) buildRuntimeCfg() *RuntimeConfig {
 		SuffixContext:    c.v.GetBool("mattermost.SuffixContext"),
 		ThreadContext:    c.v.GetString("mattermost.ThreadContext"),
 		ShowContextMulti: c.v.GetBool("mattermost.ShowContextMulti"),
-
 	}
 	slBridge := BridgeConfig{
-		Restrict:      append([]string(nil), c.v.GetStringSlice("slack.Restrict")...),
+		Restrict: append([]string(nil), c.v.GetStringSlice("slack.Restrict")...),
 
 		JoinOnly:    c.v.GetStringSlice("slack.JoinOnly"),
 		JoinExclude: c.v.GetStringSlice("slack.JoinExclude"),
@@ -183,7 +182,7 @@ func (c *Config) buildRuntimeCfg() *RuntimeConfig {
 		ShowContextMulti: c.v.GetBool("slack.ShowContextMulti"),
 	}
 	mdBridge := BridgeConfig{
-		Restrict:      append([]string(nil), c.v.GetStringSlice("mastodon.Restrict")...),
+		Restrict: append([]string(nil), c.v.GetStringSlice("mastodon.Restrict")...),
 
 		JoinOnly:    c.v.GetStringSlice("mastodon.JoinOnly"),
 		JoinExclude: c.v.GetStringSlice("mastodon.JoinExclude"),
@@ -296,7 +295,7 @@ func (c *Config) buildRuntimeCfg() *RuntimeConfig {
 			DisableDefaultMentions: c.v.GetBool("mattermost.DisableDefaultMentions"),
 			DisableShowOwnModified: c.v.GetBool("mattermost.DisableShowOwnModified"),
 
-			DisableAutoView: c.v.GetBool("mattermost.DisableAutoView"),
+			DisableAutoView:    c.v.GetBool("mattermost.DisableAutoView"),
 			LastViewedSaveFile: c.v.GetString("mattermost.LastViewedSaveFile"),
 		},
 

--- a/config/config.go
+++ b/config/config.go
@@ -58,19 +58,63 @@ type MattermostConfig struct {
 	DefaultServer string
 	DefaultTeam   string
 
-	Insecure bool
+	Insecure           bool
+	IgnoreServerVersion bool
 
-	LastViewedSaveFile string
+	JoinOnly    []string
+	JoinExclude []string
+	JoinInclude []string
 
-	DisableMarkdown bool
-	DisableEmoji    bool
+	CollapseScrollback bool
+	ShowOnlyJoined     bool
+	PartFake           bool
+
+	Restrict []string
+
+	SkipTLSVerify bool
+
+	PrefixMainTeam bool
+	DisableAutoView bool
+
+	ForceAntiIdle   bool
+	AntiIdleChannel string
+	AntiIdleInterval int
+
+	PreferNickname bool
+
+	HideReplies      bool
+	ShortenRepliesTo int
 
 	Unicode bool
+
+	HideReactions    bool
+	ShowOwnReactions bool
+
+	DisableEmoji bool
+
+	DisableMarkdown           bool
+	DisableMarkdownBlockQuote bool
+	MarkdownBlockQuoteChar    string
+	MarkdownInlineCode        string
+
+	JoinDM bool
 
 	PrefixContext bool
 	SuffixContext bool
 
+	ThreadContext   string
+	ShowContextMulti bool
+
 	ShowMentions bool
+
+	DisableDefaultMentions bool
+	DisableShowOwnModified bool
+
+	SyntaxHighlighting     string
+	DisableCodeBlockPrefix bool
+	CodeBlockPrefix        string
+
+	LastViewedSaveFile string
 }
 
 type SlackConfig struct {
@@ -115,27 +159,71 @@ func (c *Config) buildRuntimeCfg() *RuntimeConfig {
 		},
 
 		Mattermost: MattermostConfig{
+			Restrict:      append([]string(nil), c.v.GetStringSlice("mattermost.Restrict")...),
 			DefaultServer: c.v.GetString("mattermost.DefaultServer"),
 			DefaultTeam:   c.v.GetString("mattermost.DefaultTeam"),
 
-			Insecure: c.v.GetBool("mattermost.Insecure"),
+			Insecure:            c.v.GetBool("mattermost.Insecure"),
+			IgnoreServerVersion: c.v.GetBool("mattermost.IgnoreServerVersion"),
 
-			LastViewedSaveFile: c.v.GetString("mattermost.LastViewedSaveFile"),
+			JoinOnly: append([]string(nil), c.v.GetStringSlice("mattermost.JoinOnly")...),
+			JoinExclude: append([]string(nil), c.v.GetStringSlice("mattermost.JoinExclude")...),
+			JoinInclude: append([]string(nil), c.v.GetStringSlice("mattermost.JoinInclude")...),
 
-			DisableMarkdown: c.v.GetBool("mattermost.DisableMarkdown"),
-			DisableEmoji:    c.v.GetBool("mattermost.DisableEmoji"),
-			Unicode:         c.v.GetBool("mattermost.Unicode"),
+			CollapseScrollback: c.v.GetBool("mattermost.CollapseScrollback"),
+			ShowOnlyJoined:     c.v.GetBool("mattermost.ShowOnlyJoined"),
+			PartFake:           c.v.GetBool("mattermost.PartFake"),
+
+			SkipTLSVerify: c.v.GetBool("mattermost.SkipTLSVerify"),
+
+			PrefixMainTeam: c.v.GetBool("mattermost.PrefixMainTeam"),
+			DisableAutoView: c.v.GetBool("mattermost.DisableAutoView"),
+
+			ForceAntiIdle:   c.v.GetBool("mattermost.ForceAntiIdle"),
+			AntiIdleChannel: c.v.GetString("mattermost.AntiIdleChannel"),
+			AntiIdleInterval: c.v.GetInt("mattermost.AntiIdleInterval"),
+
+			PreferNickname: c.v.GetBool("mattermost.PreferNickname"),
+
+			HideReplies:      c.v.GetBool("mattermost.HideReplies"),
+			ShortenRepliesTo: c.v.GetInt("mattermost.ShortenRepliesTo"),
+
+			Unicode: c.v.GetBool("mattermost.Unicode"),
+
+			HideReactions:    c.v.GetBool("mattermost.HideReactions"),
+			ShowOwnReactions: c.v.GetBool("mattermost.ShowOwnReactions"),
+
+			DisableEmoji: c.v.GetBool("mattermost.DisableEmoji"),
+
+			DisableMarkdown:           c.v.GetBool("mattermost.DisableMarkdown"),
+			DisableMarkdownBlockQuote: c.v.GetBool("mattermost.DisableMarkdownBlockQuote"),
+			MarkdownBlockQuoteChar:    c.v.GetString("mattermost.MarkdownBlockQuoteChar"),
+			MarkdownInlineCode:        c.v.GetString("mattermost.MarkdownInlineCode"),
+
+			JoinDM: c.v.GetBool("mattermost.JoinDM"),
 
 			PrefixContext: c.v.GetBool("mattermost.PrefixContext"),
 			SuffixContext: c.v.GetBool("mattermost.SuffixContext"),
 
+			ThreadContext:    c.v.GetString("mattermost.ThreadContext"),
+			ShowContextMulti: c.v.GetBool("mattermost.ShowContextMulti"),
+
 			ShowMentions: c.v.GetBool("mattermost.ShowMentions"),
+
+			DisableDefaultMentions: c.v.GetBool("mattermost.DisableDefaultMentions"),
+			DisableShowOwnModified: c.v.GetBool("mattermost.DisableShowOwnModified"),
+
+			SyntaxHighlighting:     c.v.GetString("mattermost.SyntaxHighlighting"),
+			DisableCodeBlockPrefix: c.v.GetBool("mattermost.DisableCodeBlockPrefix"),
+			CodeBlockPrefix:        c.v.GetString("mattermost.CodeBlockPrefix"),
+
+			LastViewedSaveFile: c.v.GetString("mattermost.LastViewedSaveFile"),
 		},
 
 		Slack: SlackConfig{
+			Restrict:       append([]string(nil), c.v.GetStringSlice("slack.Restrict")...),
 			DenyUsers:      append([]string(nil), c.v.GetStringSlice("slack.DenyUsers")...),
 			JoinDM:         c.v.GetBool("slack.JoinDM"),
-			Restrict:       append([]string(nil), c.v.GetStringSlice("slack.Restrict")...),
 			UseDisplayName: c.v.GetBool("slack.UseDisplayName"),
 			PreferNickname: c.v.GetBool("slack.PreferNickname"),
 

--- a/config/config.go
+++ b/config/config.go
@@ -152,9 +152,9 @@ func (c *Config) buildRuntimeCfg() *RuntimeConfig {
 	mmBridge := BridgeConfig{
 		Restrict: append([]string(nil), c.v.GetStringSlice("mattermost.Restrict")...),
 
-		JoinOnly:    c.v.GetStringSlice("mattermost.JoinOnly"),
-		JoinExclude: c.v.GetStringSlice("mattermost.JoinExclude"),
-		JoinInclude: c.v.GetStringSlice("mattermost.JoinInclude"),
+		JoinOnly:    append([]string(nil), c.v.GetStringSlice("mattermost.joinonly")...),
+		JoinExclude: append([]string(nil), c.v.GetStringSlice("mattermost.joininclude")...),
+		JoinInclude: append([]string(nil), c.v.GetStringSlice("mattermost.joinexclude")...),
 
 		ShowJoinPart:   c.v.GetBool("mattermost.ShowJoinPart"),
 		ShowOnlyJoined: c.v.GetBool("mattermost.ShowOnlyJoined"),
@@ -168,9 +168,9 @@ func (c *Config) buildRuntimeCfg() *RuntimeConfig {
 	slBridge := BridgeConfig{
 		Restrict: append([]string(nil), c.v.GetStringSlice("slack.Restrict")...),
 
-		JoinOnly:    c.v.GetStringSlice("slack.JoinOnly"),
-		JoinExclude: c.v.GetStringSlice("slack.JoinExclude"),
-		JoinInclude: c.v.GetStringSlice("slack.JoinInclude"),
+		JoinOnly:    append([]string(nil), c.v.GetStringSlice("slack.JoinOnly")...),
+		JoinExclude: append([]string(nil), c.v.GetStringSlice("slack.JoinExclude")...),
+		JoinInclude: append([]string(nil), c.v.GetStringSlice("slack.JoinInclude")...),
 
 		ShowJoinPart:   c.v.GetBool("slack.ShowJoinPart"),
 		ShowOnlyJoined: c.v.GetBool("slack.ShowOnlyJoined"),
@@ -184,9 +184,9 @@ func (c *Config) buildRuntimeCfg() *RuntimeConfig {
 	mdBridge := BridgeConfig{
 		Restrict: append([]string(nil), c.v.GetStringSlice("mastodon.Restrict")...),
 
-		JoinOnly:    c.v.GetStringSlice("mastodon.JoinOnly"),
-		JoinExclude: c.v.GetStringSlice("mastodon.JoinExclude"),
-		JoinInclude: c.v.GetStringSlice("mastodon.JoinInclude"),
+		JoinOnly:    append([]string(nil), c.v.GetStringSlice("mastodon.JoinOnly")...),
+		JoinExclude: append([]string(nil), c.v.GetStringSlice("mastodon.JoinExclude")...),
+		JoinInclude: append([]string(nil), c.v.GetStringSlice("mastodon.JoinInclude")...),
 
 		ShowJoinPart:   c.v.GetBool("mastodon.ShowJoinPart"),
 		ShowOnlyJoined: c.v.GetBool("mastodon.ShowOnlyJoined"),

--- a/config/config.go
+++ b/config/config.go
@@ -60,6 +60,7 @@ type BridgeConfig struct {
 	JoinOnly    []string
 	JoinExclude []string
 	JoinInclude []string
+	JoinDM      bool
 
 	ShowJoinPart   bool
 	ShowOnlyJoined bool
@@ -115,8 +116,6 @@ type MattermostConfig struct {
 	HideReactions    bool
 	ShowOwnReactions bool
 
-	JoinDM bool
-
 	ShowMentions bool
 
 	DisableDefaultMentions bool
@@ -131,7 +130,6 @@ type SlackConfig struct {
 	Formatter FormatterConfig
 
 	DenyUsers      []string
-	JoinDM         bool
 	UseDisplayName bool
 	PreferNickname bool
 }
@@ -155,6 +153,7 @@ func (c *Config) buildRuntimeCfg() *RuntimeConfig {
 		JoinOnly:    append([]string(nil), c.v.GetStringSlice("mattermost.JoinOnly")...),
 		JoinExclude: append([]string(nil), c.v.GetStringSlice("mattermost.JoinExclude")...),
 		JoinInclude: append([]string(nil), c.v.GetStringSlice("mattermost.JoinInclude")...),
+		JoinDM:      c.v.GetBool("mattermost.JoinDM"),
 
 		ShowJoinPart:   c.v.GetBool("mattermost.ShowJoinPart"),
 		ShowOnlyJoined: c.v.GetBool("mattermost.ShowOnlyJoined"),
@@ -171,6 +170,7 @@ func (c *Config) buildRuntimeCfg() *RuntimeConfig {
 		JoinOnly:    append([]string(nil), c.v.GetStringSlice("slack.JoinOnly")...),
 		JoinExclude: append([]string(nil), c.v.GetStringSlice("slack.JoinExclude")...),
 		JoinInclude: append([]string(nil), c.v.GetStringSlice("slack.JoinInclude")...),
+		JoinDM:      c.v.GetBool("slack.JoinDM"),
 
 		ShowJoinPart:   c.v.GetBool("slack.ShowJoinPart"),
 		ShowOnlyJoined: c.v.GetBool("slack.ShowOnlyJoined"),
@@ -187,6 +187,7 @@ func (c *Config) buildRuntimeCfg() *RuntimeConfig {
 		JoinOnly:    append([]string(nil), c.v.GetStringSlice("mastodon.JoinOnly")...),
 		JoinExclude: append([]string(nil), c.v.GetStringSlice("mastodon.JoinExclude")...),
 		JoinInclude: append([]string(nil), c.v.GetStringSlice("mastodon.JoinInclude")...),
+		JoinDM:      c.v.GetBool("mastodon.JoinDM"),
 
 		ShowJoinPart:   c.v.GetBool("mastodon.ShowJoinPart"),
 		ShowOnlyJoined: c.v.GetBool("mastodon.ShowOnlyJoined"),
@@ -288,8 +289,6 @@ func (c *Config) buildRuntimeCfg() *RuntimeConfig {
 			HideReactions:    c.v.GetBool("mattermost.HideReactions"),
 			ShowOwnReactions: c.v.GetBool("mattermost.ShowOwnReactions"),
 
-			JoinDM: c.v.GetBool("mattermost.JoinDM"),
-
 			ShowMentions: c.v.GetBool("mattermost.ShowMentions"),
 
 			DisableDefaultMentions: c.v.GetBool("mattermost.DisableDefaultMentions"),
@@ -304,7 +303,6 @@ func (c *Config) buildRuntimeCfg() *RuntimeConfig {
 			Formatter: slFormatter,
 
 			DenyUsers:      append([]string(nil), c.v.GetStringSlice("slack.DenyUsers")...),
-			JoinDM:         c.v.GetBool("slack.JoinDM"),
 			UseDisplayName: c.v.GetBool("slack.UseDisplayName"),
 			PreferNickname: c.v.GetBool("slack.PreferNickname"),
 		},

--- a/config/config.go
+++ b/config/config.go
@@ -2,16 +2,21 @@ package config
 
 import (
 	"fmt"
+	"os"
 	"runtime"
 	"strings"
 	"sync/atomic"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
 
-var Logger *logrus.Entry
+var (
+	logger   *logrus.Entry
+	LogLevel string
+)
 
 type Config struct {
 	current atomic.Pointer[RuntimeConfig]
@@ -34,9 +39,9 @@ type RuntimeConfig struct {
 type GlobalConfig struct {
 	Bind string
 
-	Debug bool
-	Trace bool
-	Gops  bool
+	Debug   bool
+	Trace   bool
+	Gops    bool
 
 	TLSBind string
 	TLSDir  string
@@ -54,6 +59,8 @@ type MattermostConfig struct {
 	DefaultTeam   string
 
 	Insecure bool
+
+	LastViewedSaveFile string
 
 	DisableMarkdown bool
 	DisableEmoji    bool
@@ -104,6 +111,8 @@ func (c *Config) buildRuntimeCfg() *RuntimeConfig {
 
 			Insecure: c.v.GetBool("mattermost.Insecure"),
 
+			LastViewedSaveFile: c.v.GetString("mattermost.LastViewedSaveFile"),
+
 			DisableMarkdown: c.v.GetBool("mattermost.DisableMarkdown"),
 			DisableEmoji:    c.v.GetBool("mattermost.DisableEmoji"),
 			Unicode:         c.v.GetBool("mattermost.Unicode"),
@@ -129,35 +138,11 @@ func (c *Config) buildRuntimeCfg() *RuntimeConfig {
 	}
 }
 
-func (c *Config) reload() error {
-	if err := c.v.ReadInConfig(); err != nil {
-		return err
-	}
-
-	runtimeCfg := c.buildRuntimeCfg()
-
-	if err := validate(runtimeCfg); err != nil {
-		return err
-	}
-
-	c.current.Store(runtimeCfg)
-
-	if Logger != nil {
-		Logger.Info("configuration reloaded")
-	}
-
-	return nil
-}
-
-func validate(runtimeCfg *RuntimeConfig) error {
-	return nil
-}
-
 func (c *Config) Current() *RuntimeConfig {
 	return c.current.Load()
 }
 
-func Load(cfgfile string) (*Config, error) {
+func Load(cfgfile string, flags *pflag.FlagSet) (*Config, error) {
 	v := viper.New()
 	v.SetConfigFile(cfgfile)
 
@@ -170,22 +155,84 @@ func Load(cfgfile string) (*Config, error) {
 		v: v,
 	}
 
+	if err := c.v.BindPFlags(flags); err != nil {
+		return nil, err
+	}
+
+	if _, err := os.Stat(cfgfile); err != nil {
+		if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("unable to access config file %q: %w", cfgfile, err)
+		}
+
+		if err := c.publishRuntimeConfig(); err != nil {
+			return nil, err
+		}
+
+		return c, nil
+	}
+
 	if err := c.reload(); err != nil {
 		return nil, fmt.Errorf("error reading config file: %w", err)
 	}
 
-	// reload config on file changes
-	if runtime.GOOS != "illumos" {
-		v.OnConfigChange(func(e fsnotify.Event) {
-			if err := c.reload(); err != nil {
-				if Logger != nil {
-					Logger.Errorf("config reload failed: %v", err)
-				}
-			}
-		})
-
-		v.WatchConfig()
-	}
+	c.watch()
 
 	return c, nil
+}
+
+func (c *Config) publishRuntimeConfig() error {
+	runtimeCfg := c.buildRuntimeCfg()
+
+	if err := validate(runtimeCfg); err != nil {
+		return err
+	}
+
+	c.current.Store(runtimeCfg)
+
+	return nil
+}
+
+func (c *Config) reload() error {
+	if err := c.v.ReadInConfig(); err != nil {
+		return err
+	}
+
+	if err := c.publishRuntimeConfig(); err != nil {
+		return err
+	}
+
+	if logger != nil {
+		logger.Info("configuration reloaded")
+	}
+
+	return nil
+}
+
+func SetLogger(l *logrus.Entry) {
+	logger = l
+}
+
+func SetLogLevel(level logrus.Level) {
+	if logger != nil {
+		logger.Logger.SetLevel(level)
+	}
+}
+
+func validate(runtimeCfg *RuntimeConfig) error {
+	return nil
+}
+
+func (c *Config) watch() {
+	// reload config on file changes
+	if runtime.GOOS == "illumos" {
+		return
+	}
+
+	c.v.OnConfigChange(func(_ fsnotify.Event) {
+		if err := c.reload(); err != nil && logger != nil {
+			logger.WithError(err).Error("config reload failed")
+		}
+	})
+
+	c.v.WatchConfig()
 }

--- a/config/config.go
+++ b/config/config.go
@@ -57,12 +57,19 @@ type GlobalConfig struct {
 type BridgeConfig struct {
 	Restrict []string
 
-	JoinOnly    bool
+	JoinOnly    []string
 	JoinExclude []string
 	JoinInclude []string
 
 	ShowJoinPart   bool
 	ShowOnlyJoined bool
+	PartFake       bool
+
+	// Threading / context related
+	PrefixContext    bool
+	SuffixContext    bool
+	ThreadContext    string
+	ShowContextMulti bool
 }
 
 type FormatterConfig struct {
@@ -91,7 +98,6 @@ type MattermostConfig struct {
 	IgnoreServerVersion bool
 
 	CollapseScrollback bool
-	PartFake           bool
 
 	SkipTLSVerify bool
 
@@ -111,12 +117,6 @@ type MattermostConfig struct {
 	ShowOwnReactions bool
 
 	JoinDM bool
-
-	// Threading / context related
-	PrefixContext    bool
-	SuffixContext    bool
-	ThreadContext    string
-	ShowContextMulti bool
 
 	ShowMentions bool
 
@@ -152,32 +152,51 @@ func (c *Config) buildRuntimeCfg() *RuntimeConfig {
 	mmBridge := BridgeConfig{
 		Restrict:      append([]string(nil), c.v.GetStringSlice("mattermost.Restrict")...),
 
-		JoinOnly:    c.v.GetBool("mattermost.JoinOnly"),
+		JoinOnly:    c.v.GetStringSlice("mattermost.JoinOnly"),
 		JoinExclude: c.v.GetStringSlice("mattermost.JoinExclude"),
 		JoinInclude: c.v.GetStringSlice("mattermost.JoinInclude"),
 
 		ShowJoinPart:   c.v.GetBool("mattermost.ShowJoinPart"),
 		ShowOnlyJoined: c.v.GetBool("mattermost.ShowOnlyJoined"),
+		PartFake:       c.v.GetBool("mattermost.PartFake"),
+
+		PrefixContext:    c.v.GetBool("mattermost.PrefixContext"),
+		SuffixContext:    c.v.GetBool("mattermost.SuffixContext"),
+		ThreadContext:    c.v.GetString("mattermost.ThreadContext"),
+		ShowContextMulti: c.v.GetBool("mattermost.ShowContextMulti"),
+
 	}
 	slBridge := BridgeConfig{
 		Restrict:      append([]string(nil), c.v.GetStringSlice("slack.Restrict")...),
 
-		JoinOnly:    c.v.GetBool("slack.JoinOnly"),
+		JoinOnly:    c.v.GetStringSlice("slack.JoinOnly"),
 		JoinExclude: c.v.GetStringSlice("slack.JoinExclude"),
 		JoinInclude: c.v.GetStringSlice("slack.JoinInclude"),
 
 		ShowJoinPart:   c.v.GetBool("slack.ShowJoinPart"),
 		ShowOnlyJoined: c.v.GetBool("slack.ShowOnlyJoined"),
+		PartFake:       c.v.GetBool("slack.PartFake"),
+
+		PrefixContext:    c.v.GetBool("slack.PrefixContext"),
+		SuffixContext:    c.v.GetBool("slack.SuffixContext"),
+		ThreadContext:    c.v.GetString("slack.ThreadContext"),
+		ShowContextMulti: c.v.GetBool("slack.ShowContextMulti"),
 	}
 	mdBridge := BridgeConfig{
 		Restrict:      append([]string(nil), c.v.GetStringSlice("mastodon.Restrict")...),
 
-		JoinOnly:    c.v.GetBool("mastodon.JoinOnly"),
+		JoinOnly:    c.v.GetStringSlice("mastodon.JoinOnly"),
 		JoinExclude: c.v.GetStringSlice("mastodon.JoinExclude"),
 		JoinInclude: c.v.GetStringSlice("mastodon.JoinInclude"),
 
 		ShowJoinPart:   c.v.GetBool("mastodon.ShowJoinPart"),
 		ShowOnlyJoined: c.v.GetBool("mastodon.ShowOnlyJoined"),
+		PartFake:       c.v.GetBool("mastodon.PartFake"),
+
+		PrefixContext:    c.v.GetBool("mastodon.PrefixContext"),
+		SuffixContext:    c.v.GetBool("mastodon.SuffixContext"),
+		ThreadContext:    c.v.GetString("mastodon.ThreadContext"),
+		ShowContextMulti: c.v.GetBool("mastodon.ShowContextMulti"),
 	}
 
 	mmFormatter := FormatterConfig{
@@ -253,7 +272,6 @@ func (c *Config) buildRuntimeCfg() *RuntimeConfig {
 			IgnoreServerVersion: c.v.GetBool("mattermost.IgnoreServerVersion"),
 
 			CollapseScrollback: c.v.GetBool("mattermost.CollapseScrollback"),
-			PartFake:           c.v.GetBool("mattermost.PartFake"),
 
 			SkipTLSVerify: c.v.GetBool("mattermost.SkipTLSVerify"),
 
@@ -272,11 +290,6 @@ func (c *Config) buildRuntimeCfg() *RuntimeConfig {
 			ShowOwnReactions: c.v.GetBool("mattermost.ShowOwnReactions"),
 
 			JoinDM: c.v.GetBool("mattermost.JoinDM"),
-
-			PrefixContext:    c.v.GetBool("mattermost.PrefixContext"),
-			SuffixContext:    c.v.GetBool("mattermost.SuffixContext"),
-			ThreadContext:    c.v.GetString("mattermost.ThreadContext"),
-			ShowContextMulti: c.v.GetBool("mattermost.ShowContextMulti"),
 
 			ShowMentions: c.v.GetBool("mattermost.ShowMentions"),
 
@@ -314,7 +327,7 @@ func (c *Config) Current() *RuntimeConfig {
 	return c.current.Load()
 }
 
-func (c *Config) CurrentProtocol(protocol string) any {
+func (c *Config) ProtocolConfig(protocol string) any {
 	rc := c.Current()
 
 	switch protocol {
@@ -327,6 +340,18 @@ func (c *Config) CurrentProtocol(protocol string) any {
 	default:
 		return nil
 	}
+}
+
+func (c *Config) Mattermost() *MattermostConfig {
+	return &c.Current().Mattermost
+}
+
+func (c *Config) Slack() *SlackConfig {
+	return &c.Current().Slack
+}
+
+func (c *Config) Mastodon() *MastodonConfig {
+	return &c.Current().Mastodon
 }
 
 func Load(cfgfile string, flags *pflag.FlagSet) (*Config, error) {

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ var (
 	version = "0.31.0-dev"
 	githash string
 	logger  *logrus.Entry
-	cfg      *config.Config
+	cfg     *config.Config
 
 	LastViewedSaveDB *bolt.DB
 )

--- a/main.go
+++ b/main.go
@@ -56,7 +56,8 @@ func main() {
 	pflag.Parse()
 
 	// Attempt to load values from the config file
-	cfg, err := config.Load(*flagConfig, pflag.CommandLine)
+	var err error
+	cfg, err = config.Load(*flagConfig, pflag.CommandLine)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -18,14 +18,13 @@ import (
 	prefixed "github.com/matterbridge/logrus-prefixed-formatter"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
-	"github.com/spf13/viper"
 )
 
 var (
 	version = "0.31.0-dev"
 	githash string
 	logger  *logrus.Entry
-	v       *viper.Viper
+	cfg      *config.Config
 
 	LastViewedSaveDB *bolt.DB
 )
@@ -37,7 +36,7 @@ func main() {
 		FullTimestamp: true,
 	}
 	logger = ourlog.WithFields(logrus.Fields{"prefix": "matterircd"})
-	config.Logger = logger
+	config.SetLogger(logger)
 
 	// config related. instantiate a new config.Config to store flags
 	flagConfig := flag.String("conf", "matterircd.toml", "config file")
@@ -57,36 +56,31 @@ func main() {
 	pflag.Parse()
 
 	// Attempt to load values from the config file
-	if _, err := os.Stat(*flagConfig); err == nil {
-		v, err = config.LoadConfig(*flagConfig)
-		if err != nil {
-			log.Fatal(err)
-		}
-	} else {
-		v = viper.New()
+	cfg, err := config.Load(*flagConfig, pflag.CommandLine)
+	if err != nil {
+		log.Fatal(err)
 	}
+	rc := cfg.Current()
 
-	v.BindPFlags(pflag.CommandLine)
-
-	if v.GetBool("debug") {
+	if rc.Debug {
 		logger.Info("enabling debug")
-		ourlog.Level = logrus.DebugLevel
+		config.SetLogLevel(logrus.DebugLevel)
 		irckit.SetLogLevel("debug")
 	}
 
-	if v.GetBool("trace") {
+	if rc.Trace {
 		logger.Info("enabling trace")
-		ourlog.Level = logrus.TraceLevel
+		config.SetLogLevel(logrus.TraceLevel)
 		irckit.SetLogLevel("trace")
 	}
 
-	if v.GetBool("gops") {
+	if rc.Gops {
 		if err := agent.Listen(agent.Options{}); err != nil {
 			log.Fatal(err)
 		}
 	}
 
-	if v.GetBool("version") {
+	if flag.Lookup("version").Value.String() == "true" {
 		fmt.Printf("version: %s %s\n", version, githash)
 		return
 	}
@@ -98,9 +92,9 @@ func main() {
 		logger.Infof("WARNING: THIS IS A DEVELOPMENT VERSION. Things may break.")
 	}
 
-	if v.GetString("tlsbind") != "" {
+	if rc.TLSBind != "" {
 		go func() {
-			logger.Infof("Listening on %s (TLS)", v.GetString("tlsbind"))
+			logger.Infof("Listening on %s (TLS)", rc.TLSBind)
 			socket := tlsbind()
 			defer socket.Close()
 			start(socket)
@@ -108,7 +102,7 @@ func main() {
 	}
 
 	mmLastViewedFile := "matterircd-lastsaved.db"
-	if statePath := v.GetString("mattermost.LastViewedSaveFile"); statePath != "" {
+	if statePath := rc.Mattermost.LastViewedSaveFile; statePath != "" {
 		mmLastViewedFile = statePath
 	}
 	db, err := bolt.Open(mmLastViewedFile, 0o600, &bolt.Options{Timeout: 1 * time.Second})
@@ -120,22 +114,22 @@ func main() {
 
 	// backwards compatible
 
-	if v.GetString("bind") != "" {
+	if rc.Bind != "" {
 		go func() {
 			var network string
-			if strings.ContainsRune(v.GetString("bind"), os.PathSeparator) {
+			if strings.ContainsRune(rc.Bind, os.PathSeparator) {
 				network = "unix"
 			} else {
 				network = "tcp"
 			}
 
-			socket, err := net.Listen(network, v.GetString("bind"))
+			socket, err := net.Listen(network, rc.Bind)
 			if err != nil {
-				logger.Errorf("Can not listen on %s: %v", v.GetString("bind"), err)
+				logger.Errorf("Can not listen on %s: %v", rc.Bind, err)
 				os.Exit(1)
 			}
 
-			logger.Infof("Listening on %s", v.GetString("bind"))
+			logger.Infof("Listening on %s", rc.Bind)
 
 			defer socket.Close()
 			start(socket)
@@ -146,15 +140,16 @@ func main() {
 }
 
 func tlsbind() net.Listener {
-	certPath := v.GetString("tlsdir") + "/cert.pem"
-	keyPath := v.GetString("tlsdir") + "/key.pem"
+	rc := cfg.Current()
+	certPath := rc.TLSDir + "/cert.pem"
+	keyPath := rc.TLSDir + "/key.pem"
 
-	if v.GetString("tlscert") != "" {
-		certPath = v.GetString("tlscert")
+	if rc.TLSCert != "" {
+		certPath = rc.TLSCert
 	}
 
-	if v.GetString("tlskey") != "" {
-		keyPath = v.GetString("tlskey")
+	if rc.TLSKey != "" {
+		keyPath = rc.TLSKey
 	}
 
 	kpr, err := NewKeypairReloader(certPath, keyPath)
@@ -167,13 +162,13 @@ func tlsbind() net.Listener {
 		GetCertificate: kpr.GetCertificateFunc(),
 	}
 
-	listenerTLS, err := tls.Listen("tcp", v.GetString("tlsbind"), &tlsConfig)
+	listenerTLS, err := tls.Listen("tcp", rc.TLSBind, &tlsConfig)
 	if err != nil {
-		logger.Errorf("Can not listen on %s: %v\n", v.GetString("tlsbind"), err)
+		logger.Errorf("Can not listen on %s: %v\n", rc.TLSBind, err)
 		os.Exit(1)
 	}
 
-	logger.Info("TLS listening on ", v.GetString("tlsbind"))
+	logger.Info("TLS listening on ", rc.TLSBind)
 
 	return listenerTLS
 }
@@ -191,7 +186,7 @@ func start(socket net.Listener) {
 
 			logger.Infof("New connection: %s", conn.RemoteAddr())
 
-			user := irckit.NewUserBridge(conn, newsrv, v, LastViewedSaveDB)
+			user := irckit.NewUserBridge(conn, newsrv, cfg, LastViewedSaveDB)
 			err = newsrv.Connect(user)
 			if err != nil {
 				logger.Errorf("Failed to join: %v", err)

--- a/mm-go-irckit/server.go
+++ b/mm-go-irckit/server.go
@@ -413,7 +413,7 @@ func (s *server) handshake(u *User) error {
 	u.Host = u.ResolveHost()
 	go u.Decode()
 
-	timeout := u.v.GetInt("HandshakeTimeout")
+	timeout := u.cfg.Current().HandshakeTimeout
 	if timeout == 0 {
 		timeout = 10
 	}

--- a/mm-go-irckit/server_commands.go
+++ b/mm-go-irckit/server_commands.go
@@ -130,16 +130,9 @@ func CmdJoin(s Server, u *User, msg *irc.Message) error {
 
 		sync = u.syncChannel
 
-		/*u.v.GetStringSlice(u.br.Protocol()+".joinexclude")
-		u.v.Set(key string, value interface{})
-		*/
-		// if we joined, remove channel from exclude and add to include
-		u.v.Set(u.br.Protocol()+".joinexclude", removeStringInSlice(channel, u.v.GetStringSlice(u.br.Protocol()+".joinexclude")))
-
-		if len(u.v.GetStringSlice(u.br.Protocol()+".joininclude")) > 0 {
-			channels := u.v.GetStringSlice(u.br.Protocol() + ".joininclude")
+		if len(u.br.BridgeConfig().JoinInclude) > 0 {
+			channels := u.br.BridgeConfig().JoinInclude
 			channels = append(channels, channel)
-			u.v.Set(u.br.Protocol()+".joininclude", channels)
 		}
 
 		ch := s.Channel(channelID)
@@ -308,7 +301,7 @@ func CmdPart(s Server, u *User, msg *irc.Message) error {
 		// first part on irc
 		ch.Part(u, msg.Trailing)
 		// now part on mattermost/slack
-		if !u.v.GetBool(u.br.Protocol() + ".PartFake") {
+		if !u.br.BridgeConfig().PartFake {
 			err = u.br.Part(ch.ID())
 			if err != nil {
 				return err
@@ -317,9 +310,6 @@ func CmdPart(s Server, u *User, msg *irc.Message) error {
 		// part all other (ghost)users on the channel
 		for _, k := range ch.Users() {
 			ch.Part(k, "")
-			// if we parted, remove channel from include
-			u.v.Set(u.br.Protocol()+".joininclude",
-				removeStringInSlice(chName, u.v.GetStringSlice(u.br.Protocol()+".joininclude")))
 		}
 	}
 
@@ -403,7 +393,7 @@ func CmdPrivMsg(s Server, u *User, msg *irc.Message) error {
 		u.msgLast[ch.ID()] = [2]string{msgID, ""}
 		u.saveLastViewedAt(ch.ID())
 
-		if u.v.GetBool(u.br.Protocol()+".prefixcontext") || u.v.GetBool(u.br.Protocol()+".suffixcontext") {
+		if u.br.BridgeConfig().PrefixContext || u.br.BridgeConfig().SuffixContext {
 			u.prefixContext(ch.ID(), msgID, "", "posted_self")
 		}
 
@@ -449,7 +439,7 @@ func CmdPrivMsg(s Server, u *User, msg *irc.Message) error {
 			u.msgLast[toUser.User] = [2]string{msgID, ""}
 			u.saveLastViewedAt(toUser.User)
 
-			if u.v.GetBool(u.br.Protocol()+".prefixcontext") || u.v.GetBool(u.br.Protocol()+".suffixcontext") {
+			if u.br.BridgeConfig().PrefixContext || u.br.BridgeConfig().SuffixContext {
 				u.prefixContext(toUser.User, msgID, "", "posted_self")
 			}
 
@@ -652,7 +642,7 @@ func threadMsgChannelUser(u *User, msg *irc.Message, channelID string, toUser bo
 	u.msgLast[channelID] = [2]string{msgID, threadID}
 	u.saveLastViewedAt(channelID)
 
-	if u.v.GetBool(u.br.Protocol()+".prefixcontext") || u.v.GetBool(u.br.Protocol()+".suffixcontext") {
+	if u.br.BridgeConfig().PrefixContext || u.br.BridgeConfig().SuffixContext {
 		u.prefixContext(channelID, msgID, threadID, "posted_self")
 	}
 

--- a/mm-go-irckit/server_commands.go
+++ b/mm-go-irckit/server_commands.go
@@ -130,11 +130,6 @@ func CmdJoin(s Server, u *User, msg *irc.Message) error {
 
 		sync = u.syncChannel
 
-		if len(u.br.BridgeConfig().JoinInclude) > 0 {
-			channels := u.br.BridgeConfig().JoinInclude
-			channels = append(channels, channel)
-		}
-
 		ch := s.Channel(channelID)
 		sync(channelID, channelName)
 		ch.Join(u)

--- a/mm-go-irckit/service.go
+++ b/mm-go-irckit/service.go
@@ -563,7 +563,7 @@ func scrollback(u *User, toUser *User, args []string, service string) {
 		}
 	}
 
-	if u.cfg.Mattermost().CollapseScrollback {
+	if !u.cfg.Mattermost().CollapseScrollback {
 		u.MsgUser(toUser, fmt.Sprintf("scrollback results shown in %s", search))
 	}
 }

--- a/mm-go-irckit/service.go
+++ b/mm-go-irckit/service.go
@@ -134,17 +134,17 @@ func login(u *User, toUser *User, args []string, service string) {
 	case cred.Server != "":
 		cred.Team = teamOrServer
 	// Missing both server and team, let's use DefaultServer and DefaultTeam.
-	case teamOrServer == "" && u.v.GetString("mattermost.DefaultServer") != "" && u.v.GetString("mattermost.DefaultTeam") != "":
-		cred.Server = u.v.GetString("mattermost.DefaultServer")
-		cred.Team = u.v.GetString("mattermost.DefaultTeam")
+	case teamOrServer == "" && u.cfg.Mattermost().DefaultServer != "" && u.cfg.Mattermost().DefaultTeam != "":
+		cred.Server = u.cfg.Mattermost().DefaultServer
+		cred.Team = u.cfg.Mattermost().DefaultTeam
 	// Missing server, let's use DefaultServer.
-	case u.v.GetString("mattermost.DefaultServer") != "":
-		cred.Server = u.v.GetString("mattermost.DefaultServer")
+	case u.cfg.Mattermost().DefaultServer != "":
+		cred.Server = u.cfg.Mattermost().DefaultServer
 		cred.Team = teamOrServer
 	// Missing team, let's use DefaultTeam.
-	case u.v.GetString("mattermost.DefaultTeam") != "":
+	case u.cfg.Mattermost().DefaultTeam != "":
 		cred.Server = teamOrServer
-		cred.Team = u.v.GetString("mattermost.DefaultTeam")
+		cred.Team = u.cfg.Mattermost().DefaultTeam
 	default:
 		cred.Server = teamOrServer
 	}
@@ -223,7 +223,7 @@ func details(u *User, toUser *User, args []string, service string) {
 	postID := args[0]
 
 	proto := "https"
-	if u.v.GetBool(u.br.Protocol() + ".insecure") {
+	if u.cfg.Mattermost().Insecure {
 		proto = "http"
 	}
 	postlistURL := proto + "://" + u.Credentials.Server + "/" + u.Credentials.Team + "/pl/"
@@ -350,16 +350,16 @@ func formatSearchMsg(u *User, channelID string, channel string, user *User, nick
 	ts := time.Unix(0, p.CreateAt*int64(time.Millisecond))
 
 	switch {
-	case (u.v.GetBool(u.br.Protocol()+".collapsescrollback") && strings.HasPrefix(channel, "#")):
+	case (u.cfg.Mattermost().CollapseScrollback && strings.HasPrefix(channel, "#")):
 		threadMsgID := u.prefixContext(channelID, p.Id, p.RootId, "scrollback")
 		msg := u.formatContextMessage(ts.Format("2006-01-02 15:04"), threadMsgID, msgText)
 		nick += "/" + channel
 		u.Srv.Channel("&messages").SpoofMessage(nick, msg)
-	case u.v.GetBool(u.br.Protocol() + ".collapsescrollback"):
+	case u.cfg.Mattermost().CollapseScrollback:
 		threadMsgID := u.prefixContext(channelID, p.Id, p.RootId, "scrollback")
 		msg := u.formatContextMessage(ts.Format("2006-01-02 15:04"), threadMsgID, msgText)
 		u.Srv.Channel("&messages").SpoofMessage(nick, msg)
-	case (u.v.GetBool(u.br.Protocol()+".prefixcontext") || u.v.GetBool(u.br.Protocol()+".suffixcontext")) && strings.HasPrefix(channel, "#"):
+	case (u.br.BridgeConfig().PrefixContext || u.br.BridgeConfig().SuffixContext) && strings.HasPrefix(channel, "#"):
 		threadMsgID := u.prefixContext(channelID, p.Id, p.RootId, "scrollback")
 		nick += "/" + channel
 		msg := u.formatContextMessage(ts.Format("2006-01-02 15:04"), threadMsgID, "<"+nick+"> "+msgText)
@@ -368,7 +368,7 @@ func formatSearchMsg(u *User, channelID string, channel string, user *User, nick
 		nick += "/" + channel
 		msg := "[" + ts.Format("2006-01-02 15:04") + "] <" + nick + "> " + msgText
 		u.MsgUser(user, msg)
-	case u.v.GetBool(u.br.Protocol()+".prefixcontext") || u.v.GetBool(u.br.Protocol()+".suffixcontext"):
+	case u.br.BridgeConfig().PrefixContext || u.br.BridgeConfig().SuffixContext:
 		threadMsgID := u.prefixContext(channelID, p.Id, p.RootId, "scrollback")
 		msg := u.formatContextMessage(ts.Format("2006-01-02 15:04"), threadMsgID, "<"+nick+"> "+msgText)
 		u.MsgUser(user, msg)
@@ -454,7 +454,7 @@ func scrollback(u *User, toUser *User, args []string, service string) {
 	scrollbackUser, exists := u.Srv.HasUser(search)
 
 	proto := "https"
-	if u.v.GetBool(u.br.Protocol() + ".insecure") {
+	if u.cfg.Mattermost().Insecure {
 		proto = "http"
 	}
 	postlistURL := proto + "://" + u.Credentials.Server + "/" + u.Credentials.Team + "/pl/"
@@ -563,7 +563,7 @@ func scrollback(u *User, toUser *User, args []string, service string) {
 		}
 	}
 
-	if !u.v.GetBool(u.br.Protocol() + ".collapsescrollback") {
+	if u.cfg.Mattermost().CollapseScrollback {
 		u.MsgUser(toUser, fmt.Sprintf("scrollback results shown in %s", search))
 	}
 }
@@ -572,24 +572,24 @@ func formatScrollbackMsg(u *User, channelID string, channel string, user *User, 
 	ts := time.Unix(0, p.CreateAt*int64(time.Millisecond))
 
 	switch {
-	case (u.v.GetBool(u.br.Protocol()+".collapsescrollback") && strings.HasPrefix(channel, "#")):
+	case (u.cfg.Mattermost().CollapseScrollback && strings.HasPrefix(channel, "#")):
 		threadMsgID := u.prefixContext(channelID, p.Id, p.RootId, "scrollback")
 		msg := u.formatContextMessage(ts.Format("2006-01-02 15:04"), threadMsgID, msgText)
 		nick += "/" + channel
 		u.Srv.Channel("&messages").SpoofMessage(nick, msg)
-	case u.v.GetBool(u.br.Protocol() + ".collapsescrollback"):
+	case u.cfg.Mattermost().CollapseScrollback:
 		threadMsgID := u.prefixContext(channelID, p.Id, p.RootId, "scrollback")
 		msg := u.formatContextMessage(ts.Format("2006-01-02 15:04"), threadMsgID, msgText)
 		nick += "/" + channel
 		u.Srv.Channel("&messages").SpoofMessage(nick, msg)
-	case (u.v.GetBool(u.br.Protocol()+".prefixcontext") || u.v.GetBool(u.br.Protocol()+".suffixcontext")) && strings.HasPrefix(channel, "#") && nick != systemUser:
+	case (u.br.BridgeConfig().PrefixContext || u.br.BridgeConfig().SuffixContext) && strings.HasPrefix(channel, "#") && nick != systemUser:
 		threadMsgID := u.prefixContext(channelID, p.Id, p.RootId, "scrollback")
 		msg := u.formatContextMessage(ts.Format("2006-01-02 15:04"), threadMsgID, msgText)
 		u.Srv.Channel(channelID).SpoofMessage(nick, msg)
 	case strings.HasPrefix(channel, "#"):
 		msg := "[" + ts.Format("2006-01-02 15:04") + "] " + msgText
 		u.Srv.Channel(channelID).SpoofMessage(nick, msg)
-	case u.v.GetBool(u.br.Protocol()+".prefixcontext") || u.v.GetBool(u.br.Protocol()+".suffixcontext"):
+	case u.br.BridgeConfig().PrefixContext || u.br.BridgeConfig().SuffixContext:
 		threadMsgID := u.prefixContext(channelID, p.Id, p.RootId, "scrollback")
 		msg := u.formatContextMessage(ts.Format("2006-01-02 15:04"), threadMsgID, msgText)
 		u.MsgSpoofUser(user, nick, msg)

--- a/mm-go-irckit/user.go
+++ b/mm-go-irckit/user.go
@@ -10,9 +10,9 @@ import (
 	"time"
 
 	"github.com/42wim/matterircd/bridge"
+	"github.com/42wim/matterircd/config"
 	"github.com/desertbit/timer"
 	"github.com/sorcix/irc"
-	"github.com/spf13/viper"
 )
 
 // NewUser creates a *User, wrapping a connection with metadata we need for our server.
@@ -49,7 +49,7 @@ type User struct {
 
 	channels map[Channel]struct{}
 
-	v *viper.Viper
+	cfg *config.Config
 
 	UserBridge
 }
@@ -173,7 +173,7 @@ func (u *User) Decode() {
 		return
 	}
 	buffer := make(chan *irc.Message, 512)
-	bufferTimeout := u.v.GetInt("PasteBufferTimeout")
+	bufferTimeout := u.cfg.Current().PasteBufferTimeout
 	// we need at least 100
 	if bufferTimeout < 100 {
 		bufferTimeout = 100
@@ -295,4 +295,17 @@ func (u *User) createService(nick string, what string) {
 			Host:  "service",
 			Ghost: true,
 		})
+}
+
+func (u *User) protocolConfig() any {
+	switch u.br.Protocol() {
+	case "mattermost":
+		return &u.cfg.Current().Mattermost
+	case "slack":
+		return &u.cfg.Current().Slack
+	case "mastodon":
+		return &u.cfg.Current().Mastodon
+	default:
+		return nil
+	}
 }

--- a/mm-go-irckit/user.go
+++ b/mm-go-irckit/user.go
@@ -296,16 +296,3 @@ func (u *User) createService(nick string, what string) {
 			Ghost: true,
 		})
 }
-
-func (u *User) protocolConfig() any {
-	switch u.br.Protocol() {
-	case "mattermost":
-		return &u.cfg.Current().Mattermost
-	case "slack":
-		return &u.cfg.Current().Slack
-	case "mastodon":
-		return &u.cfg.Current().Mastodon
-	default:
-		return nil
-	}
-}

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -753,7 +753,7 @@ func (u *User) addUsersToChannels() {
 		logger.Debugf("Adding channel %#v", brchannel)
 
 		// only joindm when specified
-		if brchannel.DM && u.br.Protocol() == "mattermost" && !u.cfg.Mattermost().JoinDM {
+		if brchannel.DM && !u.br.BridgeConfig().JoinDM {
 			logger.Debugf("Skipping IM channel %s", brchannel.Name)
 
 			continue

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -16,13 +16,13 @@ import (
 	"github.com/42wim/matterircd/bridge/mastodon"
 	"github.com/42wim/matterircd/bridge/mattermost"
 	"github.com/42wim/matterircd/bridge/slack"
+	"github.com/42wim/matterircd/config"
 	"github.com/42wim/matterircd/utils"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/kenshaw/emoji"
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/muesli/reflow/wordwrap"
 	"github.com/sorcix/irc"
-	"github.com/spf13/viper"
 )
 
 const systemUser = "system"
@@ -52,7 +52,7 @@ type UserBridge struct {
 	updateCounter      map[string]time.Time
 }
 
-func NewUserBridge(c net.Conn, srv Server, cfg *viper.Viper, db *bolt.DB) *User {
+func NewUserBridge(c net.Conn, srv Server, cfg *config.Config, db *bolt.DB) *User {
 	u := NewUser(&conn{
 		Conn:    c,
 		Encoder: irc.NewEncoder(c),
@@ -60,7 +60,6 @@ func NewUserBridge(c net.Conn, srv Server, cfg *viper.Viper, db *bolt.DB) *User 
 	})
 
 	u.Srv = srv
-	u.v = cfg
 	u.lastViewedAtDB = db
 	u.msgLast = make(map[string][2]string)
 	u.msgMap = make(map[string]map[string]int)
@@ -137,14 +136,14 @@ const (
 )
 
 func (u *User) getMarkdownBlockCodePrefix() (string, string) {
-	disableMarkdown := u.v.GetBool(u.br.Protocol() + ".disablemarkdown")
-	enableUnicode := u.v.GetBool(u.br.Protocol() + ".unicode")
+	disableMarkdown := u.br.FormatterConfig().DisableMarkdown
+	enableUnicode := u.br.FormatterConfig().Unicode
 
 	// Block quotes
 	var blockQuoteChar string
-	if u.v.GetBool(u.br.Protocol()+".disablemarkdownblockquote") || disableMarkdown {
+	if u.br.FormatterConfig().DisableMarkdownBlockQuote || disableMarkdown {
 		blockQuoteChar = blockQuoteCharDefault
-	} else if custom := u.v.GetString(u.br.Protocol() + ".markdownblockquotechar"); custom != "" {
+	} else if custom := u.br.FormatterConfig().MarkdownBlockQuoteChar; custom != "" {
 		blockQuoteChar = custom
 	} else if enableUnicode {
 		blockQuoteChar = blockQuoteCharUnicode
@@ -154,9 +153,9 @@ func (u *User) getMarkdownBlockCodePrefix() (string, string) {
 
 	// Code blocks
 	var codeBlockPrefix string
-	if u.v.GetBool(u.br.Protocol()+".disablecodeblockprefix") || disableMarkdown {
+	if u.br.FormatterConfig().DisableCodeBlockPrefix || disableMarkdown {
 		codeBlockPrefix = codeBlockCharDefault
-	} else if custom := u.v.GetString(u.br.Protocol() + ".codeblockprefix"); custom != "" {
+	} else if custom := u.br.FormatterConfig().CodeBlockPrefix; custom != "" {
 		codeBlockPrefix = custom
 	} else if enableUnicode {
 		codeBlockPrefix = codeBlockPrefixUnicode
@@ -168,7 +167,7 @@ func (u *User) getMarkdownBlockCodePrefix() (string, string) {
 }
 
 func (u *User) handleDirectMessageEvent(event *bridge.DirectMessageEvent) {
-	if u.v.GetBool(u.br.Protocol() + ".showmentions") {
+	if u.br.Protocol() == "mattermost" && u.cfg.Mattermost().ShowMentions {
 		for _, m := range u.MentionKeys {
 			if m == u.Nick {
 				continue
@@ -187,9 +186,9 @@ func (u *User) handleDirectMessageEvent(event *bridge.DirectMessageEvent) {
 	var showContext bool
 	var maxlen int
 
-	disableMarkdown := u.v.GetBool(u.br.Protocol() + ".disablemarkdown")
+	disableMarkdown := u.br.FormatterConfig().DisableMarkdown
 	blockQuoteChar, codeBlockPrefix := u.getMarkdownBlockCodePrefix()
-	inlineCode := u.v.GetString(u.br.Protocol() + ".markdowninlinecode")
+	inlineCode := u.br.FormatterConfig().MarkdownInlineCode
 
 	text := event.Text
 	prefix := ""
@@ -212,10 +211,10 @@ func (u *User) handleDirectMessageEvent(event *bridge.DirectMessageEvent) {
 	trimmedPrefix := strings.TrimSpace(prefix)
 	trimmedSuffix := strings.TrimSpace(suffix)
 
-	disableEmoji := u.v.GetBool(u.br.Protocol() + ".disableemoji")
-	prefixContext := u.v.GetBool(u.br.Protocol() + ".prefixcontext")
-	showContextMulti := u.v.GetBool(u.br.Protocol() + ".showcontextmulti")
-	syntaxHighlighting := u.v.GetString(u.br.Protocol() + ".syntaxhighlighting")
+	disableEmoji := u.br.FormatterConfig().DisableEmoji
+	prefixContext := u.br.BridgeConfig().PrefixContext
+	showContextMulti := u.br.BridgeConfig().ShowContextMulti
+	syntaxHighlighting := u.br.FormatterConfig().SyntaxHighlighting
 
 	lexer := ""
 	codeBlockBackTick := false
@@ -276,7 +275,7 @@ func (u *User) handleDirectMessageEvent(event *bridge.DirectMessageEvent) {
 		text = rest
 	}
 
-	if !u.v.GetBool(u.br.Protocol() + ".disableautoview") {
+	if u.br.Protocol() == "mattermost" && !u.cfg.Mattermost().DisableAutoView {
 		u.updateLastViewed(event.ChannelID)
 	}
 	u.saveLastViewedAt(event.ChannelID)
@@ -300,7 +299,7 @@ func (u *User) handleChannelAddEvent(event *bridge.ChannelAddEvent) {
 		}
 	}
 
-	if !u.v.GetBool(u.br.Protocol() + ".disableautoview") {
+	if u.br.Protocol() == "mattermost" && !u.cfg.Mattermost().DisableAutoView {
 		u.updateLastViewed(event.ChannelID)
 	}
 	u.saveLastViewedAt(event.ChannelID)
@@ -369,13 +368,13 @@ func (u *User) handleChannelMessageEvent(event *bridge.ChannelMessageEvent) {
 	}
 
 	if event.ChannelType != "D" && ch.ID() == "&messages" {
-		if u.v.GetBool(u.br.Protocol() + ".showonlyjoined") {
+		if u.br.BridgeConfig().ShowOnlyJoined {
 			return
 		}
 		nick += "/" + u.Srv.Channel(event.ChannelID).String()
 	}
 
-	if u.v.GetBool(u.br.Protocol() + ".showmentions") {
+	if u.br.Protocol() == "mattermost" && u.cfg.Mattermost().ShowMentions {
 		for _, m := range u.MentionKeys {
 			if m == u.Nick {
 				continue
@@ -391,9 +390,9 @@ func (u *User) handleChannelMessageEvent(event *bridge.ChannelMessageEvent) {
 		}
 	}
 
-	disableMarkdown := u.v.GetBool(u.br.Protocol() + ".disablemarkdown")
+	disableMarkdown := u.br.FormatterConfig().DisableMarkdown
 	blockQuoteChar, codeBlockPrefix := u.getMarkdownBlockCodePrefix()
-	inlineCode := u.v.GetString(u.br.Protocol() + ".markdowninlinecode")
+	inlineCode := u.br.FormatterConfig().MarkdownInlineCode
 
 	text := event.Text
 	prefix := ""
@@ -413,10 +412,10 @@ func (u *User) handleChannelMessageEvent(event *bridge.ChannelMessageEvent) {
 	trimmedPrefix := strings.TrimSpace(prefix)
 	trimmedSuffix := strings.TrimSpace(suffix)
 
-	disableEmoji := u.v.GetBool(u.br.Protocol() + ".disableemoji")
-	prefixContext := u.v.GetBool(u.br.Protocol() + ".prefixcontext")
-	showContextMulti := u.v.GetBool(u.br.Protocol() + ".showcontextmulti")
-	syntaxHighlighting := u.v.GetString(u.br.Protocol() + ".syntaxhighlighting")
+	disableEmoji := u.br.FormatterConfig().DisableEmoji
+	prefixContext := u.br.BridgeConfig().PrefixContext
+	showContextMulti := u.br.BridgeConfig().ShowContextMulti
+	syntaxHighlighting := u.br.FormatterConfig().SyntaxHighlighting
 
 	lexer := ""
 	codeBlockBackTick := false
@@ -474,14 +473,14 @@ func (u *User) handleChannelMessageEvent(event *bridge.ChannelMessageEvent) {
 		text = rest
 	}
 
-	if !u.v.GetBool(u.br.Protocol() + ".disableautoview") {
+	if u.br.Protocol() == "mattermost" && !u.cfg.Mattermost().DisableAutoView {
 		u.updateLastViewed(event.ChannelID)
 	}
 	u.saveLastViewedAt(event.ChannelID)
 }
 
 func (u *User) handleFileEvent(event *bridge.FileEvent) {
-	if u.v.GetBool(u.br.Protocol()+".showonlyjoined") && event.ChannelType != "D" {
+	if u.br.BridgeConfig().ShowOnlyJoined && event.ChannelType != "D" {
 		ch := u.getMessageChannel(event.ChannelID, event.Sender)
 		if ch.ID() == "&messages" {
 			return
@@ -490,7 +489,7 @@ func (u *User) handleFileEvent(event *bridge.FileEvent) {
 
 	for _, fname := range event.Files {
 		fileMsg := "\x1ddownload file - " + fname.Name + "\x1d"
-		if u.v.GetBool(u.br.Protocol()+".prefixcontext") || u.v.GetBool(u.br.Protocol()+".suffixcontext") {
+		if u.br.BridgeConfig().PrefixContext || u.br.BridgeConfig().SuffixContext {
 			threadMsgID := u.prefixContext(event.ChannelID, event.MessageID, event.ParentID, "posted_file")
 			fileMsg = u.formatContextMessage("", threadMsgID, fileMsg)
 		}
@@ -597,12 +596,12 @@ func (u *User) handleReactionEvent(event interface{}) {
 
 	defer u.saveLastViewedAt(channelID)
 
-	if u.v.GetBool(u.br.Protocol() + ".hidereactions") {
+	if u.br.Protocol() == "mattermost" && u.cfg.Mattermost().HideReactions {
 		logger.Debug("Not showing reaction: " + text + reaction)
 		return
 	}
 
-	if !u.v.GetBool(u.br.Protocol() + ".disableemoji") {
+	if !u.br.FormatterConfig().DisableEmoji {
 		reactionEmoji := emoji.FromAlias(reaction)
 		if reactionEmoji != nil {
 			reaction = reactionEmoji.Emoji
@@ -753,7 +752,7 @@ func (u *User) addUsersToChannels() {
 		logger.Debugf("Adding channel %#v", brchannel)
 
 		// only joindm when specified
-		if brchannel.DM && !u.v.GetBool(u.br.Protocol()+".joindm") {
+		if brchannel.DM && u.br.Protocol() == "mattermost" && !u.cfg.Mattermost().JoinDM {
 			logger.Debugf("Skipping IM channel %s", brchannel.Name)
 
 			continue
@@ -787,7 +786,7 @@ func (u *User) createSpoof(mmchannel *bridge.ChannelInfo) func(string, string, .
 
 	channelName := mmchannel.Name
 
-	if mmchannel.TeamID != u.br.GetMe().TeamID || u.v.GetBool(u.br.Protocol()+".prefixmainteam") {
+	if mmchannel.TeamID != u.br.GetMe().TeamID || (u.br.Protocol() == "mattermost" && u.cfg.Mattermost().PrefixMainTeam) {
 		channelName = u.br.GetTeamName(mmchannel.TeamID) + "/" + mmchannel.Name
 	}
 
@@ -926,7 +925,7 @@ func (u *User) addUserToChannelWorker(channels <-chan *bridge.ChannelInfo, throt
 				}
 
 				replayMsg := fmt.Sprintf("[%s] %s", ts.Format("15:04"), post)
-				if (u.v.GetBool(u.br.Protocol()+".prefixcontext") || u.v.GetBool(u.br.Protocol()+".suffixcontext")) && nick != systemUser {
+				if (u.br.BridgeConfig().PrefixContext || u.br.BridgeConfig().SuffixContext) && nick != systemUser {
 					threadMsgID := u.prefixContext(brchannel.ID, p.Id, p.RootId, "replay")
 					replayMsg = u.formatContextMessage(ts.Format("15:04"), threadMsgID, post)
 				}
@@ -939,7 +938,7 @@ func (u *User) addUserToChannelWorker(channels <-chan *bridge.ChannelInfo, throt
 
 			for _, fname := range u.br.GetFileLinks(p.FileIds) {
 				fileMsg := "\x1ddownload file - " + fname + "\x1d"
-				if u.v.GetBool(u.br.Protocol()+".prefixcontext") || u.v.GetBool(u.br.Protocol()+".suffixcontext") {
+				if u.br.BridgeConfig().PrefixContext || u.br.BridgeConfig().SuffixContext {
 					threadMsgID := u.prefixContext(brchannel.ID, p.Id, p.RootId, "replay_file")
 					fileMsg = u.formatContextMessage(ts.Format("15:04"), threadMsgID, fileMsg)
 				}
@@ -948,7 +947,7 @@ func (u *User) addUserToChannelWorker(channels <-chan *bridge.ChannelInfo, throt
 		}
 
 		if len(mmPostList.Order) > 0 {
-			if !u.v.GetBool(u.br.Protocol() + ".disableautoview") {
+			if u.br.Protocol() == "mattermost" && !u.cfg.Mattermost().DisableAutoView {
 				u.updateLastViewed(brchannel.ID)
 			}
 			u.saveLastViewedAt(brchannel.ID)
@@ -1026,9 +1025,9 @@ func (u *User) syncChannel(id string, name string) {
 func (u *User) mayJoin(channelID string) bool {
 	ch := u.Srv.Channel(channelID)
 
-	jo := u.v.GetStringSlice(u.br.Protocol() + ".joinonly")
-	ji := u.v.GetStringSlice(u.br.Protocol() + ".joininclude")
-	je := u.v.GetStringSlice(u.br.Protocol() + ".joinexclude")
+	jo := u.br.BridgeConfig().JoinOnly
+	ji := u.br.BridgeConfig().JoinInclude
+	je := u.br.BridgeConfig().JoinExclude
 
 	switch {
 	// if we have joinonly channels specified we are only allowed to join those
@@ -1063,13 +1062,13 @@ func (u *User) mayJoin(channelID string) bool {
 }
 
 func (u *User) isValidServer(server, protocol string) bool {
-	if len(u.v.GetStringSlice(protocol+".restrict")) == 0 {
+	if len(u.br.BridgeConfig().Restrict) == 0 {
 		return true
 	}
 
-	logger.Debugf("restrict: %s", u.v.GetStringSlice(protocol+".restrict"))
+	logger.Debugf("restrict: %s", u.br.BridgeConfig().Restrict)
 
-	for _, srv := range u.v.GetStringSlice(protocol + ".restrict") {
+	for _, srv := range u.br.BridgeConfig().Restrict {
 		if srv == server {
 			return true
 		}
@@ -1084,14 +1083,14 @@ func (u *User) loginTo(protocol string) error {
 	switch protocol {
 	case "mastodon":
 		u.eventChan = make(chan *bridge.Event)
-		u.br, err = mastodon.New(u.v, u.Credentials, u.eventChan, u.addUsersToChannels)
+		u.br, err = mastodon.New(u.cfg, u.Credentials, u.eventChan, u.addUsersToChannels)
 	case "slack":
 		u.eventChan = make(chan *bridge.Event)
-		u.br, err = slack.New(u.v, u.Credentials, u.eventChan, u.addUsersToChannels)
+		u.br, err = slack.New(u.cfg, u.Credentials, u.eventChan, u.addUsersToChannels)
 	case "mattermost":
 		u.eventChan = make(chan *bridge.Event)
-		if u.v.GetBool("mattermost.ignoreserverversion") || strings.HasPrefix(u.getMattermostVersion(), "7.") || strings.HasPrefix(u.getMattermostVersion(), "8.") || strings.HasPrefix(u.getMattermostVersion(), "9.") || strings.HasPrefix(u.getMattermostVersion(), "10.") || strings.HasPrefix(u.getMattermostVersion(), "11.") {
-			u.br, _, err = mattermost.New(u.v, u.Credentials, u.eventChan, u.addUsersToChannels)
+		if u.cfg.Mattermost().IgnoreServerVersion || strings.HasPrefix(u.getMattermostVersion(), "7.") || strings.HasPrefix(u.getMattermostVersion(), "8.") || strings.HasPrefix(u.getMattermostVersion(), "9.") || strings.HasPrefix(u.getMattermostVersion(), "10.") || strings.HasPrefix(u.getMattermostVersion(), "11.") {
+			u.br, _, err = mattermost.New(u.cfg, u.Credentials, u.eventChan, u.addUsersToChannels)
 		} else {
 			return fmt.Errorf("mattermost version %s not supported", u.getMattermostVersion())
 		}
@@ -1186,9 +1185,9 @@ func (u *User) updateMsgMapIndex(channelID string, counter int, messageID string
 func (u *User) formatContextMessage(ts, threadMsgID, msg string) string {
 	var formattedMsg string
 	switch {
-	case u.v.GetBool(u.br.Protocol() + ".prefixcontext"):
+	case u.br.BridgeConfig().PrefixContext:
 		formattedMsg = threadMsgID + " " + msg
-	case u.v.GetBool(u.br.Protocol() + ".suffixcontext"):
+	case u.br.BridgeConfig().SuffixContext:
 		formattedMsg = msg + " " + threadMsgID
 	}
 	if ts != "" {
@@ -1201,15 +1200,15 @@ func (u *User) prefixContext(channelID, messageID, parentID, event string) strin
 	logger.Tracef("prefixContext ch %s msg %s parent %s event %s", channelID, messageID, parentID, event)
 
 	prefixChar := "->"
-	if u.v.GetBool(u.br.Protocol() + ".unicode") {
+	if u.br.FormatterConfig().Unicode {
 		prefixChar = "↪"
 	}
 
-	if u.v.GetString(u.br.Protocol()+".threadcontext") == "mattermost" || u.v.GetString(u.br.Protocol()+".threadcontext") == "mattermost+post" {
+	if u.br.BridgeConfig().ThreadContext == "mattermost" || u.br.BridgeConfig().ThreadContext == "mattermost+post" {
 		if parentID == "" {
 			return "[@@" + messageID + "]"
 		}
-		if u.v.GetString(u.br.Protocol()+".threadcontext") == "mattermost" || parentID == messageID {
+		if u.br.BridgeConfig().ThreadContext == "mattermost" || parentID == messageID {
 			return "[" + prefixChar + "@@" + parentID + "]"
 		}
 		return "[" + prefixChar + "@@" + parentID + ",@@" + messageID + "]"
@@ -1288,8 +1287,7 @@ func (u *User) saveLastViewedAt(channelID string) {
 
 func (u *User) getMattermostVersion() string {
 	proto := "https"
-
-	if u.v.GetBool("mattermost.insecure") {
+	if u.cfg.Mattermost().Insecure {
 		proto = "http"
 	}
 
@@ -1312,26 +1310,26 @@ func (u *User) handleMessageThreadContext(channelID, messageID, parentID, event,
 
 	newText := text
 	switch {
-	case u.v.GetBool(u.br.Protocol()+".prefixcontext") && strings.HasPrefix(text, "\x01"):
+	case u.br.BridgeConfig().PrefixContext && strings.HasPrefix(text, "\x01"):
 		prefix = u.prefixContext(channelID, messageID, parentID, event) + " "
 		newText = strings.Replace(text, "\x01ACTION ", "\x01ACTION "+prefix, 1)
 		maxlen = len(newText)
-	case u.v.GetBool(u.br.Protocol()+".prefixcontext") && u.v.GetBool(u.br.Protocol()+".showcontextmulti"):
+	case u.br.BridgeConfig().PrefixContext && u.br.BridgeConfig().ShowContextMulti:
 		prefix = u.prefixContext(channelID, messageID, parentID, event) + " "
 		showContext = true
 		maxlen -= len(prefix)
-	case u.v.GetBool(u.br.Protocol() + ".prefixcontext"):
+	case u.br.BridgeConfig().PrefixContext:
 		prefix = u.prefixContext(channelID, messageID, parentID, event) + " "
 		newText = prefix + text
-	case u.v.GetBool(u.br.Protocol()+".suffixcontext") && strings.HasSuffix(text, "\x01"):
+	case u.br.BridgeConfig().SuffixContext && strings.HasSuffix(text, "\x01"):
 		suffix = " " + u.prefixContext(channelID, messageID, parentID, event)
 		newText = strings.Replace(text, " \x01", suffix+" \x01", 1)
 		maxlen = len(newText)
-	case u.v.GetBool(u.br.Protocol()+".suffixcontext") && u.v.GetBool(u.br.Protocol()+".showcontextmulti"):
+	case u.br.BridgeConfig().SuffixContext && u.br.BridgeConfig().ShowContextMulti:
 		suffix = " " + u.prefixContext(channelID, messageID, parentID, event)
 		showContext = true
 		maxlen -= len(suffix)
-	case u.v.GetBool(u.br.Protocol() + ".suffixcontext"):
+	case u.br.BridgeConfig().SuffixContext:
 		suffix = " " + u.prefixContext(channelID, messageID, parentID, event)
 		newText = strings.TrimRight(text, "\n") + suffix
 	}

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -60,6 +60,7 @@ func NewUserBridge(c net.Conn, srv Server, cfg *config.Config, db *bolt.DB) *Use
 	})
 
 	u.Srv = srv
+	u.cfg = cfg
 	u.lastViewedAtDB = db
 	u.msgLast = make(map[string][2]string)
 	u.msgMap = make(map[string]map[string]int)
@@ -1062,13 +1063,29 @@ func (u *User) mayJoin(channelID string) bool {
 }
 
 func (u *User) isValidServer(server, protocol string) bool {
-	if len(u.br.BridgeConfig().Restrict) == 0 {
+	var restrict []string
+
+	switch protocol {
+	case "mattermost":
+		restrict = u.cfg.Mattermost().Bridge.Restrict
+
+	case "slack":
+		restrict = u.cfg.Slack().Bridge.Restrict
+
+	case "mastodon":
+		restrict = u.cfg.Mastodon().Bridge.Restrict
+
+	default:
 		return true
 	}
 
-	logger.Debugf("restrict: %s", u.br.BridgeConfig().Restrict)
+	if len(restrict) == 0 {
+		return true
+	}
 
-	for _, srv := range u.br.BridgeConfig().Restrict {
+	logger.Debugf("restrict: %v", restrict)
+
+	for _, srv := range restrict {
 		if srv == server {
 			return true
 		}


### PR DESCRIPTION
Fixes #673

Changes to config include fixing hot-reloading causing crashes with concurrent map read/writes as reported in #673. In addition to that, we're reducing memory allocations as part of work for #626. Viper causes lots of memory allocations:

| Showing nodes accounting for 664.17MB, 86.35% of 769.16MB total
| Dropped 424 nodes (cum <= 3.85MB)
|       flat  flat%   sum%        cum   cum%
| ...
|     1.50MB   0.2% 38.41%    40.51MB  5.27%  github.com/spf13/cast.ToStringMapE
|    21.01MB  2.73% 46.27%    39.01MB  5.07%  fmt.Errorf

Calls to `fmt.Errorf` are from Viper:

| (pprof) tree fmt.Errorf
| Active filters:
|    focus=fmt.Errorf
| Showing nodes accounting for 31.01MB, 6.57% of 471.82MB total
| ----------------------------------------------------------+-------------
|       flat  flat%   sum%        cum   cum%   calls calls% + context
| ----------------------------------------------------------+-------------
|                                            31.01MB   100% |   github.com/spf13/cast.ToStringMapE
|    15.51MB  3.29%  3.29%    31.01MB  6.57%                | fmt.Errorf
|                                            15.50MB 49.99% |   fmt.(*pp).doPrintf

This replaces the AI slop generated in #675 with something that's still AI assisted.