### PR TITLE
Reduce memory allocations by improving how we handle emojis and reactions

### DIFF
--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -1188,7 +1188,7 @@ func (m *Mattermost) handleWsActionPost(rmsg *model.WebSocketEvent) {
 		m.eventChan <- event
 	default:
 		messageType := ""
-		if !rc.Mattermost.DisableDefaultMentions && channelMentionsRegExp.MatchString(data.Message) {
+		if !rc.Mattermost.DisableDefaultMentions && channelMentionsRegExp.MatchString(sbMsg.String()) {
 			messageType = "notice"
 		}
 
@@ -1213,7 +1213,7 @@ func (m *Mattermost) handleWsActionPost(rmsg *model.WebSocketEvent) {
 		m.handleFileEvent(channelType, ghost, &data, rmsg)
 	}
 
-	logger.Debugf("handleWsActionPost() user %s sent %#v", ghost.Nick, data.Message)
+	logger.Debugf("handleWsActionPost() user %s sent %#v", ghost.Nick, sbMsg.String())
 	logger.Debugf("%#v", data) //nolint:govet
 }
 

--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -15,7 +15,6 @@ import (
 	"github.com/42wim/matterircd/utils"
 	"github.com/davecgh/go-spew/spew"
 	lru "github.com/hashicorp/golang-lru"
-	"github.com/kenshaw/emoji"
 	prefixed "github.com/matterbridge/logrus-prefixed-formatter"
 	"github.com/matterbridge/matterclient"
 	"github.com/mattermost/mattermost-server/v6/model"
@@ -777,7 +776,7 @@ func (m *Mattermost) wsActionPostSkip(rmsg *model.WebSocketEvent) bool {
 	}
 
 	if !disableEmoji {
-		lastSentMsg = emoji.ReplaceAliases(lastSentMsg)
+		lastSentMsg = utils.EmojiReplaceAliases(lastSentMsg)
 	}
 
 	lastSentMsg = maybeShorten(lastSentMsg, 90, "@", useUnicode)
@@ -908,7 +907,7 @@ func (m *Mattermost) getParentReplyMsg(parentID string, preFetchedPost *model.Po
 	}
 
 	if !disableEmoji {
-		msg = emoji.ReplaceAliases(msg)
+		msg = utils.EmojiReplaceAliases(msg)
 	}
 
 	parentUser := m.GetUser(parentPost.UserId)
@@ -1791,7 +1790,7 @@ func (m *Mattermost) parseMessageAttachments(attachments []*model.SlackAttachmen
 			}
 
 			if !disableEmoji {
-				fallbackText = emoji.ReplaceAliases(fallbackText)
+				fallbackText = utils.EmojiReplaceAliases(fallbackText)
 			}
 
 			b.WriteString(fallbackText)
@@ -1802,7 +1801,7 @@ func (m *Mattermost) parseMessageAttachments(attachments []*model.SlackAttachmen
 			b.WriteString(prefix)
 			authorName := attachment.AuthorName
 			if !disableEmoji {
-				authorName = emoji.ReplaceAliases(authorName)
+				authorName = utils.EmojiReplaceAliases(authorName)
 			}
 			b.WriteString(authorName)
 			if attachment.AuthorLink != "" {
@@ -1818,7 +1817,7 @@ func (m *Mattermost) parseMessageAttachments(attachments []*model.SlackAttachmen
 			b.WriteByte('\x02')
 			title := attachment.Title
 			if !disableEmoji {
-				title = emoji.ReplaceAliases(title)
+				title = utils.EmojiReplaceAliases(title)
 			}
 			b.WriteString(title)
 			b.WriteByte('\x02')
@@ -1845,7 +1844,7 @@ func (m *Mattermost) parseMessageAttachments(attachments []*model.SlackAttachmen
 				}
 
 				if !disableEmoji && !codeBlockBackTick && !codeBlockTilde {
-					line = emoji.ReplaceAliases(line)
+					line = utils.EmojiReplaceAliases(line)
 				}
 
 				b.WriteString(prefix)
@@ -1885,8 +1884,8 @@ func (m *Mattermost) parseMessageAttachments(attachments []*model.SlackAttachmen
 				title := field.Title
 				nextTitle := nextField.Title
 				if !disableEmoji {
-					title = emoji.ReplaceAliases(title)
-					nextTitle = emoji.ReplaceAliases(nextTitle)
+					title = utils.EmojiReplaceAliases(title)
+					nextTitle = utils.EmojiReplaceAliases(nextTitle)
 				}
 				b.WriteString(fmt.Sprintf("%-30s %s", title, nextTitle))
 				b.WriteByte('\x02')
@@ -1915,8 +1914,8 @@ func (m *Mattermost) parseMessageAttachments(attachments []*model.SlackAttachmen
 						v2 = utils.Markdown2irc(v2, blockquoteChar, inlineCode)
 					}
 					if !disableEmoji {
-						v1 = emoji.ReplaceAliases(v1)
-						v2 = emoji.ReplaceAliases(v2)
+						v1 = utils.EmojiReplaceAliases(v1)
+						v2 = utils.EmojiReplaceAliases(v2)
 					}
 					b.WriteString(fmt.Sprintf("%-30s %s", v1, v2))
 					b.WriteByte('\n')
@@ -1931,7 +1930,7 @@ func (m *Mattermost) parseMessageAttachments(attachments []*model.SlackAttachmen
 					b.WriteByte('\x02')
 					title := field.Title
 					if !disableEmoji {
-						title = emoji.ReplaceAliases(title)
+						title = utils.EmojiReplaceAliases(title)
 					}
 					b.WriteString(title)
 					b.WriteByte('\x02')
@@ -1952,7 +1951,7 @@ func (m *Mattermost) parseMessageAttachments(attachments []*model.SlackAttachmen
 					}
 
 					if !disableEmoji && !codeBlockBackTick && !codeBlockTilde {
-						line = emoji.ReplaceAliases(line)
+						line = utils.EmojiReplaceAliases(line)
 					}
 
 					// Ignore duplicate content when field value is the same as fallback

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -603,7 +603,7 @@ func (u *User) handleReactionEvent(event interface{}) {
 
 	if !u.br.FormatterConfig().DisableEmoji {
 		if reactionEmoji, ok := utils.EmojiFromAlias(reaction); ok {
-			reaction = reactionEmoji.Emoji
+			reaction = reactionEmoji
 		}
 	}
 

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -603,7 +603,7 @@ func (u *User) handleReactionEvent(event interface{}) {
 
 	if !u.br.FormatterConfig().DisableEmoji {
 		if reactionEmoji, ok := utils.EmojiFromAlias(reaction); ok {
-			reaction = reactionEmoji
+			reaction = reactionEmoji.Emoji
 		}
 	}
 

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -19,7 +19,6 @@ import (
 	"github.com/42wim/matterircd/config"
 	"github.com/42wim/matterircd/utils"
 	"github.com/davecgh/go-spew/spew"
-	"github.com/kenshaw/emoji"
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/muesli/reflow/wordwrap"
 	"github.com/sorcix/irc"
@@ -247,7 +246,7 @@ func (u *User) handleDirectMessageEvent(event *bridge.DirectMessageEvent) {
 		}
 
 		if !disableEmoji && !codeBlockBackTick && !codeBlockTilde {
-			line = emoji.ReplaceAliases(line)
+			line = utils.EmojiReplaceAliases(line)
 		}
 
 		if showContext || addPrefix {
@@ -448,7 +447,7 @@ func (u *User) handleChannelMessageEvent(event *bridge.ChannelMessageEvent) {
 		}
 
 		if !disableEmoji && !codeBlockBackTick && !codeBlockTilde {
-			line = emoji.ReplaceAliases(line)
+			line = utils.EmojiReplaceAliases(line)
 		}
 
 		if showContext || addPrefix {
@@ -603,9 +602,8 @@ func (u *User) handleReactionEvent(event interface{}) {
 	}
 
 	if !u.br.FormatterConfig().DisableEmoji {
-		reactionEmoji := emoji.FromAlias(reaction)
-		if reactionEmoji != nil {
-			reaction = reactionEmoji.Emoji
+		if reactionEmoji, ok := utils.EmojiFromAlias(reaction); ok {
+			reaction = reactionEmoji
 		}
 	}
 

--- a/utils/formatters.go
+++ b/utils/formatters.go
@@ -196,6 +196,15 @@ func initEmoji() {
 			aliasPairs = append(aliasPairs, ":"+alias+":", e.Emoji)
 			reactionMap[alias] = e.Emoji
 		}
+		// in addition to aliases, also include tags
+		for _, tag := range e.Tags {
+			if tag == "" {
+				continue
+			}
+			// but only if it doesn't already exist, e.g. "angry"
+			aliasPairs = append(aliasPairs, ":"+tag+":", e.Emoji)
+			reactionMap[tag] = e.Emoji
+		}
 	}
 
 	emojiReplacer = strings.NewReplacer(aliasPairs...)

--- a/utils/formatters.go
+++ b/utils/formatters.go
@@ -177,6 +177,9 @@ var (
 	emojiInitOnce sync.Once
 	emojiReplacer *strings.Replacer
 	reactionMap   map[string]string
+
+	emojiSkinTonesRE   = regexp.MustCompile(`^(.+?)_((?:neutral|light|medium_light|medium|medium_dark|dark))_skin_tone$`)
+	emojiSkinTonesList = []string{"light", "medium_light", "medium", "medium_dark", "dark"}
 )
 
 func initEmoji() {
@@ -195,15 +198,37 @@ func initEmoji() {
 			}
 			aliasPairs = append(aliasPairs, ":"+alias+":", e.Emoji)
 			reactionMap[alias] = e.Emoji
+			if !e.SkinTones {
+				continue
+			}
+			// Include skin tones
+			for _, skinTone := range emojiSkinTonesList {
+				aWithTone := alias + "_" + skinTone + "_skin_tone"
+				tone, _ := emoji.ParseSkinTone(skinTone)
+				aliasPairs = append(aliasPairs, ":"+aWithTone+":", e.Tone(tone))
+				reactionMap[aWithTone] = e.Emoji
+			}
 		}
-		// in addition to aliases, also include tags
+		// In addition to emoji aliases, include emoji tags
 		for _, tag := range e.Tags {
 			if tag == "" {
 				continue
 			}
-			// but only if it doesn't already exist, e.g. "angry"
-			aliasPairs = append(aliasPairs, ":"+tag+":", e.Emoji)
-			reactionMap[tag] = e.Emoji
+			// But only if it doesn't already exist, e.g. "angry"
+			if _, ok := reactionMap[tag]; !ok {
+				aliasPairs = append(aliasPairs, ":"+tag+":", e.Emoji)
+				reactionMap[tag] = e.Emoji
+				if !e.SkinTones {
+					continue
+				}
+				// Include skin tones
+				for _, skinTone := range emojiSkinTonesList {
+					aWithTone := tag + "_" + skinTone + "_skin_tone"
+					tone, _ := emoji.ParseSkinTone(skinTone)
+					aliasPairs = append(aliasPairs, ":"+aWithTone+":", e.Tone(tone))
+					reactionMap[aWithTone] = e.Emoji
+				}
+			}
 		}
 	}
 

--- a/utils/formatters.go
+++ b/utils/formatters.go
@@ -175,8 +175,9 @@ func Markdown2irc(msg string, blockQuoteChar string, inlineCode string) string {
 
 var (
 	emojiInitOnce sync.Once
+	emojiData     []emoji.Emoji
 	emojiReplacer *strings.Replacer
-	reactionMap   map[string]string
+	emojiAliasMap map[string]int
 
 	emojiSkinTonesRE   = regexp.MustCompile(`^(.+?)_((?:neutral|light|medium_light|medium|medium_dark|dark))_skin_tone$`)
 	emojiSkinTonesList = []string{"light", "medium_light", "medium", "medium_dark", "dark"}
@@ -186,9 +187,9 @@ func initEmoji() {
 	data := emoji.Gemoji()
 
 	var aliasPairs []string
-	reactionMap = make(map[string]string, len(data))
+	emojiAliasMap = make(map[string]int, len(data))
 
-	for _, e := range data {
+	for i, e := range data {
 		if e.Emoji == "" {
 			continue
 		}
@@ -196,17 +197,15 @@ func initEmoji() {
 			if alias == "" {
 				continue
 			}
-			aliasPairs = append(aliasPairs, ":"+alias+":", e.Emoji)
-			reactionMap[alias] = e.Emoji
+			emojiAliasMap[alias], aliasPairs = i, append(aliasPairs, ":"+alias+":", e.Emoji)
 			if !e.SkinTones {
 				continue
 			}
 			// Include skin tones
-			for _, skinTone := range emojiSkinTonesList {
-				aWithTone := alias + "_" + skinTone + "_skin_tone"
-				tone, _ := emoji.ParseSkinTone(skinTone)
-				aliasPairs = append(aliasPairs, ":"+aWithTone+":", e.Tone(tone))
-				reactionMap[aWithTone] = e.Emoji
+			for _, tone := range emojiSkinTonesList {
+				aliasTone := alias + "_" + tone + "_skin_tone"
+				skinTone, _ := emoji.ParseSkinTone(tone)
+				emojiAliasMap[aliasTone], aliasPairs = i, append(aliasPairs, ":"+aliasTone+":", e.Tone(skinTone))
 			}
 		}
 		// In addition to emoji aliases, include emoji tags
@@ -215,33 +214,54 @@ func initEmoji() {
 				continue
 			}
 			// But only if it doesn't already exist, e.g. "angry"
-			if _, ok := reactionMap[tag]; !ok {
-				aliasPairs = append(aliasPairs, ":"+tag+":", e.Emoji)
-				reactionMap[tag] = e.Emoji
+			if _, ok := emojiAliasMap[tag]; !ok {
+				emojiAliasMap[tag], aliasPairs = i, append(aliasPairs, ":"+tag+":", e.Emoji)
 				if !e.SkinTones {
 					continue
 				}
 				// Include skin tones
-				for _, skinTone := range emojiSkinTonesList {
-					aWithTone := tag + "_" + skinTone + "_skin_tone"
-					tone, _ := emoji.ParseSkinTone(skinTone)
-					aliasPairs = append(aliasPairs, ":"+aWithTone+":", e.Tone(tone))
-					reactionMap[aWithTone] = e.Emoji
+				for _, tone := range emojiSkinTonesList {
+					aliasTone := tag + "_" + tone + "_skin_tone"
+					skinTone, _ := emoji.ParseSkinTone(tone)
+					emojiAliasMap[aliasTone], aliasPairs = i, append(aliasPairs, ":"+aliasTone+":", e.Tone(skinTone))
 				}
 			}
 		}
 	}
 
+	emojiData = data
 	emojiReplacer = strings.NewReplacer(aliasPairs...)
 }
 
 func EmojiReplaceAliases(s string) string {
+	if !strings.Contains(s, ":") {
+		return s
+	}
 	emojiInitOnce.Do(initEmoji)
 	return emojiReplacer.Replace(s)
 }
 
-func EmojiFromAlias(alias string) (string, bool) {
+func EmojiFromAlias(alias string) (*emoji.Emoji, bool) {
 	emojiInitOnce.Do(initEmoji)
-	val, ok := reactionMap[alias]
-	return val, ok
+	if strings.HasPrefix(alias, ":") && strings.HasSuffix(alias, ":") {
+		alias = alias[1 : len(alias)-1]
+	}
+	skinTone := emoji.Neutral
+	// Support skin tones
+	matches := emojiSkinTonesRE.FindStringSubmatch(alias)
+	if len(matches) == 3 {
+		alias = matches[1]
+		skinTone, _ = emoji.ParseSkinTone(matches[2])
+	}
+	val, ok := emojiAliasMap[alias]
+	if !ok {
+		return nil, false
+	}
+	if skinTone == emoji.Neutral {
+		return &emojiData[val], true
+	}
+	modifiedEmoji := emojiData[val]
+	tonedString := modifiedEmoji.Tone(skinTone)
+	modifiedEmoji.Emoji = tonedString
+	return &modifiedEmoji, true
 }

--- a/utils/formatters.go
+++ b/utils/formatters.go
@@ -241,27 +241,31 @@ func EmojiReplaceAliases(s string) string {
 	return emojiReplacer.Replace(s)
 }
 
-func EmojiFromAlias(alias string) (*emoji.Emoji, bool) {
+func EmojiFromAlias(alias string) (string, bool) {
 	emojiInitOnce.Do(initEmoji)
+
+	if alias == "" {
+		return "", false
+	}
 	if strings.HasPrefix(alias, ":") && strings.HasSuffix(alias, ":") {
 		alias = alias[1 : len(alias)-1]
 	}
-	skinTone := emoji.Neutral
+
 	// Support skin tones
-	matches := emojiSkinTonesRE.FindStringSubmatch(alias)
-	if len(matches) == 3 {
-		alias = matches[1]
-		skinTone, _ = emoji.ParseSkinTone(matches[2])
+	if m := emojiSkinTonesRE.FindStringSubmatch(alias); len(m) == 3 {
+		base := m[1]
+		tone := m[2]
+		idx, ok := emojiAliasMap[base]
+		if !ok {
+			return "", false
+		}
+		skinTone, _ := emoji.ParseSkinTone(tone)
+		return emojiData[idx].Tone(skinTone), true
 	}
-	val, ok := emojiAliasMap[alias]
+
+	idx, ok := emojiAliasMap[alias]
 	if !ok {
-		return nil, false
+		return "", false
 	}
-	if skinTone == emoji.Neutral {
-		return &emojiData[val], true
-	}
-	modifiedEmoji := emojiData[val]
-	tonedString := modifiedEmoji.Tone(skinTone)
-	modifiedEmoji.Emoji = tonedString
-	return &modifiedEmoji, true
+	return emojiData[idx].Emoji, true
 }

--- a/utils/formatters.go
+++ b/utils/formatters.go
@@ -178,10 +178,21 @@ var (
 	emojiData     []emoji.Emoji
 	emojiReplacer *strings.Replacer
 	emojiAliasMap map[string]int
-
-	emojiSkinTonesRE   = regexp.MustCompile(`^(.+?)_((?:neutral|light|medium_light|medium|medium_dark|dark))_skin_tone$`)
-	emojiSkinTonesList = []string{"light", "medium_light", "medium", "medium_dark", "dark"}
 )
+
+type emojiSkinToneInfo struct {
+	suffix string
+	match  string
+	tone   emoji.SkinTone
+}
+
+var emojiSkinTones = []emojiSkinToneInfo{
+	{"light", "_light", emoji.Light},
+	{"medium_light", "_medium_light", emoji.MediumLight},
+	{"medium", "_medium", emoji.Medium},
+	{"medium_dark", "_medium_dark", emoji.MediumDark},
+	{"dark", "_dark", emoji.Dark},
+}
 
 func initEmoji() {
 	data := emoji.Gemoji()
@@ -202,10 +213,9 @@ func initEmoji() {
 				continue
 			}
 			// Include skin tones
-			for _, tone := range emojiSkinTonesList {
-				aliasTone := alias + "_" + tone + "_skin_tone"
-				skinTone, _ := emoji.ParseSkinTone(tone)
-				emojiAliasMap[aliasTone], aliasPairs = i, append(aliasPairs, ":"+aliasTone+":", e.Tone(skinTone))
+			for _, st := range emojiSkinTones {
+				aliasTone := alias + "_" + st.suffix + "_skin_tone"
+				aliasPairs = append(aliasPairs, ":"+aliasTone+":", e.Tone(st.tone))
 			}
 		}
 		// In addition to emoji aliases, include emoji tags
@@ -220,10 +230,9 @@ func initEmoji() {
 					continue
 				}
 				// Include skin tones
-				for _, tone := range emojiSkinTonesList {
-					aliasTone := tag + "_" + tone + "_skin_tone"
-					skinTone, _ := emoji.ParseSkinTone(tone)
-					emojiAliasMap[aliasTone], aliasPairs = i, append(aliasPairs, ":"+aliasTone+":", e.Tone(skinTone))
+				for _, st := range emojiSkinTones {
+					aliasTone := tag + "_" + st.suffix + "_skin_tone"
+					aliasPairs = append(aliasPairs, ":"+aliasTone+":", e.Tone(st.tone))
 				}
 			}
 		}
@@ -234,7 +243,7 @@ func initEmoji() {
 }
 
 func EmojiReplaceAliases(s string) string {
-	if !strings.Contains(s, ":") {
+	if strings.IndexByte(s, ':') < 0 {
 		return s
 	}
 	emojiInitOnce.Do(initEmoji)
@@ -242,30 +251,42 @@ func EmojiReplaceAliases(s string) string {
 }
 
 func EmojiFromAlias(alias string) (string, bool) {
-	emojiInitOnce.Do(initEmoji)
-
 	if alias == "" {
 		return "", false
 	}
-	if strings.HasPrefix(alias, ":") && strings.HasSuffix(alias, ":") {
-		alias = alias[1 : len(alias)-1]
-	}
 
-	// Support skin tones
-	if m := emojiSkinTonesRE.FindStringSubmatch(alias); len(m) == 3 {
-		base := m[1]
-		tone := m[2]
-		idx, ok := emojiAliasMap[base]
-		if !ok {
-			return "", false
+	emojiInitOnce.Do(initEmoji)
+
+	if a, ok := strings.CutPrefix(alias, ":"); ok {
+		if a, ok := strings.CutSuffix(a, ":"); ok {
+			alias = a
 		}
-		skinTone, _ := emoji.ParseSkinTone(tone)
-		return emojiData[idx].Tone(skinTone), true
 	}
 
-	idx, ok := emojiAliasMap[alias]
+	if idx, ok := emojiAliasMap[alias]; ok {
+		return emojiData[idx].Emoji, true
+	}
+
+	base, ok := strings.CutSuffix(alias, "_skin_tone")
 	if !ok {
 		return "", false
 	}
-	return emojiData[idx].Emoji, true
+
+	// Support skin tones
+	for _, st := range emojiSkinTones {
+		if !strings.HasSuffix(base, st.match) {
+			continue
+		}
+
+		baseAlias := strings.TrimSuffix(base, st.match)
+
+		idx, ok := emojiAliasMap[baseAlias]
+		if !ok {
+			return "", false
+		}
+
+		return emojiData[idx].Tone(st.tone), true
+	}
+
+	return "", false
 }

--- a/utils/formatters.go
+++ b/utils/formatters.go
@@ -5,8 +5,10 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/alecthomas/chroma/v2/quick"
+	"github.com/kenshaw/emoji"
 )
 
 //nolint:funlen,gocyclo
@@ -169,4 +171,43 @@ func Markdown2irc(msg string, blockQuoteChar string, inlineCode string) string {
 	}
 
 	return msg
+}
+
+var (
+	emojiInitOnce sync.Once
+	emojiReplacer *strings.Replacer
+	reactionMap   map[string]string
+)
+
+func initEmoji() {
+	data := emoji.Gemoji()
+
+	var aliasPairs []string
+	reactionMap = make(map[string]string, len(data))
+
+	for _, e := range data {
+		if e.Emoji == "" {
+			continue
+		}
+		for _, alias := range e.Aliases {
+			if alias == "" {
+				continue
+			}
+			aliasPairs = append(aliasPairs, ":"+alias+":", e.Emoji)
+			reactionMap[alias] = e.Emoji
+		}
+	}
+
+	emojiReplacer = strings.NewReplacer(aliasPairs...)
+}
+
+func EmojiReplaceAliases(s string) string {
+	emojiInitOnce.Do(initEmoji)
+	return emojiReplacer.Replace(s)
+}
+
+func EmojiFromAlias(alias string) (string, bool) {
+	emojiInitOnce.Do(initEmoji)
+	val, ok := reactionMap[alias]
+	return val, ok
 }


### PR DESCRIPTION
Using [kenshaw/emoji](https://github.com/kenshaw/emoji) as is causes more memory allocations than we want with loading and reloading of the Gemoji data (part of work for #626):

```
| $ go tool pprof -alloc_space -top -cum http://irc-proxy.local:6060/debug/pprof/heap 2>/dev/null | grep -v '^[[:space:]]*0[[:space:]]*' 2>&1 | grep -v 'runtime/pprof' | head -n 32 | File: matterircd
| Build ID: a5f552b4f8f023dad763fa5135eef71f4d7f4b90 | Type: alloc_space
| Time: 2026-07-22 07:15:15 AEST
| Showing nodes accounting for 735.71MB, 84.05% of 875.34MB total | Dropped 395 nodes (cum <= 4.38MB)
|       flat  flat%   sum%        cum   cum%
|    15.51MB  1.77%  1.77%   140.10MB 16.01%  github.com/goccy/go-json/internal/decoder.(*ptrDecoder).DecodeStream
|       31MB  3.54%  5.31%   132.19MB 15.10%  github.com/goccy/go-json/internal/decoder.(*mapDecoder).DecodeStream
|     2.03MB  0.23%  5.55%   124.27MB 14.20%  github.com/matterbridge/matterclient.(*Client).GetChannelUsers
|    89.15MB 10.18% 15.73%    89.15MB 10.18%  github.com/kenshaw/emoji.Gemoji
|    82.05MB  9.37% 25.10%    82.05MB  9.37%  github.com/goccy/go-json/internal/decoder.(*mapDecoder).mapassign
| ...
```

We replace this with loading once. This will also allow us to add additional custom emoji aliases and overrides (#632).

Related upstream changes - https://github.com/kenshaw/emoji/pull/7