### PR TITLE
Reduce memory allocations by replacing reflow/wordwrap with a more simple word/line wrapping function

### DIFF
--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -796,31 +796,24 @@ func (m *Mattermost) wsActionPostSkip(rmsg *model.WebSocketEvent) bool {
 // maybeShorten returns a prefix of msg that is approximately newLen
 // characters long, followed by "...".  Words that start with uncounted
 // are included in the result but are not reckoned against newLen.
+//nolint:gocyclo
 func maybeShorten(msg string, newLen int, uncounted string, unicode bool) string {
 	if newLen == 0 || len(msg) < newLen {
 		return msg
 	}
-
 	ellipsis := "..."
 	if unicode {
 		ellipsis = "…"
 	}
-
 	var b strings.Builder
-	// We know len(msg) >= newLen because of the check above,
-	// so we can size the buffer perfectly for the shortened string.
 	b.Grow(newLen + 8)
-
 	i := 0
 	for i < len(msg) {
 		if b.Len() >= newLen {
 			break
 		}
-
 		switch {
 		case msg[i] == ' ' || msg[i] == '\t' || msg[i] == '\n':
-			// Preserve spaces/tabs verbatim; newlines collapse to a single
-			// space so the result stays a one-line preview.
 			for i < len(msg) && (msg[i] == ' ' || msg[i] == '\t' || msg[i] == '\n') {
 				if b.Len() >= newLen {
 					break
@@ -832,32 +825,30 @@ func maybeShorten(msg string, newLen int, uncounted string, unicode bool) string
 				}
 				i++
 			}
-
 		default:
 			start := i
 			for i < len(msg) && msg[i] != ' ' && msg[i] != '\t' && msg[i] != '\n' {
 				i++
 			}
 			word := msg[start:i]
-
-			// Handle uncounted prefixes and word truncation
 			if uncounted != "" && strings.HasPrefix(word, uncounted) {
 				newLen += len(word) + 1
 			} else if len(word) > newLen {
-				// Truncate very long words, but only if they were not skipped, on the
-				// assumption that such words are important enough to be preserved whole.
-				word = word[:newLen*2/3] + "[" + ellipsis + "]"
+				cut := newLen * 2 / 3
+				if cut > len(word) {
+					cut = len(word)
+				}
+				for cut > 0 && (word[cut]&0xC0) == 0x80 {
+					cut--
+				}
+				word = word[:cut] + "[" + ellipsis + "]"
 			}
-
 			b.WriteString(word)
 		}
 	}
-
-	// We also want to reset any formatting which can be carried over from shortening
 	b.WriteByte('\x0f')
 	b.WriteByte(' ')
 	b.WriteString(ellipsis)
-
 	return b.String()
 }
 

--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -796,8 +796,6 @@ func (m *Mattermost) wsActionPostSkip(rmsg *model.WebSocketEvent) bool {
 // maybeShorten returns a prefix of msg that is approximately newLen
 // characters long, followed by "...".  Words that start with uncounted
 // are included in the result but are not reckoned against newLen.
-//
-//nolint:cyclop
 func maybeShorten(msg string, newLen int, uncounted string, unicode bool) string {
 	if newLen == 0 || len(msg) < newLen {
 		return msg
@@ -813,43 +811,45 @@ func maybeShorten(msg string, newLen int, uncounted string, unicode bool) string
 	// so we can size the buffer perfectly for the shortened string.
 	b.Grow(newLen + 8)
 
-	start := 0
+	i := 0
+	for i < len(msg) {
+		if b.Len() >= newLen {
+			break
+		}
 
-	// Scan the string sequentially just like WrapMessage
-	for i := 0; i <= len(msg); i++ {
-		if i == len(msg) || msg[i] == ' ' || msg[i] == '\n' || msg[i] == '\t' { //nolint:nestif
-			if start < i {
-				word := msg[start:i]
-
+		switch {
+		case msg[i] == ' ' || msg[i] == '\t' || msg[i] == '\n':
+			// Preserve spaces/tabs verbatim; newlines collapse to a single
+			// space so the result stays a one-line preview.
+			for i < len(msg) && (msg[i] == ' ' || msg[i] == '\t' || msg[i] == '\n') {
 				if b.Len() >= newLen {
 					break
 				}
-
-				// Handle uncounted prefixes and word truncation
-				if uncounted != "" && strings.HasPrefix(word, uncounted) {
-					newLen += len(word) + 1
-				} else if len(word) > newLen {
-					// Truncate very long words, but only if they were not skipped, on the
-					// assumption that such words are important enough to be preserved whole.
-					word = word[:newLen*2/3] + "[" + ellipsis + "]"
-				}
-
-				b.WriteString(word)
-			}
-
-			// Explicitly write the delimiters to preserve multiple spaces
-			if i < len(msg) {
-				if b.Len() >= newLen {
-					break
-				}
-				if msg[i] == ' ' || msg[i] == '\t'{
-					b.WriteByte(msg[i])
-				} else if msg[i] == '\n' {
+				if msg[i] == '\n' {
 					b.WriteByte(' ')
+				} else {
+					b.WriteByte(msg[i])
 				}
+				i++
 			}
 
-			start = i + 1
+		default:
+			start := i
+			for i < len(msg) && msg[i] != ' ' && msg[i] != '\t' && msg[i] != '\n' {
+				i++
+			}
+			word := msg[start:i]
+
+			// Handle uncounted prefixes and word truncation
+			if uncounted != "" && strings.HasPrefix(word, uncounted) {
+				newLen += len(word) + 1
+			} else if len(word) > newLen {
+				// Truncate very long words, but only if they were not skipped, on the
+				// assumption that such words are important enough to be preserved whole.
+				word = word[:newLen*2/3] + "[" + ellipsis + "]"
+			}
+
+			b.WriteString(word)
 		}
 	}
 

--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -818,7 +818,7 @@ func maybeShorten(msg string, newLen int, uncounted string, unicode bool) string
 	// Scan the string sequentially just like WrapMessage
 	for i := 0; i <= len(msg); i++ {
 		// Detect word boundaries: space, newline, or end of string
-		if i == len(msg) || msg[i] == ' ' || msg[i] == '\n' {
+		if i == len(msg) || msg[i] == ' ' || msg[i] == '\n' { //nolint:nestif
 			// Process the word if we actually captured characters (collapses double spaces/newlines)
 			if start < i {
 				word := msg[start:i]

--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -158,7 +158,9 @@ func (m *Mattermost) handleWsMessage(quitChan chan struct{}) {
 			return
 		case message := <-m.mc.MessageChan:
 			logger.Debugf("MMUser WsReceiver: %#v", message.Raw)
-			logger.Tracef("handleWsMessage %s", spew.Sdump(message))
+			if logger.Level.String() == "trace" {
+				logger.Tracef("handleWsMessage %s", spew.Sdump(message))
+			}
 
 			switch message.Raw.EventType() {
 			case model.WebsocketEventPosted:

--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -817,13 +817,10 @@ func maybeShorten(msg string, newLen int, uncounted string, unicode bool) string
 
 	// Scan the string sequentially just like WrapMessage
 	for i := 0; i <= len(msg); i++ {
-		// Detect word boundaries: space, newline, or end of string
-		if i == len(msg) || msg[i] == ' ' || msg[i] == '\n' { //nolint:nestif
-			// Process the extracted word
+		if i == len(msg) || msg[i] == ' ' || msg[i] == '\n' || msg[i] == '\t' { //nolint:nestif
 			if start < i {
 				word := msg[start:i]
 
-				// Stop if we hit the limit
 				if b.Len() >= newLen {
 					break
 				}
@@ -845,8 +842,8 @@ func maybeShorten(msg string, newLen int, uncounted string, unicode bool) string
 				if b.Len() >= newLen {
 					break
 				}
-				if msg[i] == ' ' {
-					b.WriteByte(' ')
+				if msg[i] == ' ' || msg[i] == '\t'{
+					b.WriteByte(msg[i])
 				} else if msg[i] == '\n' {
 					b.WriteByte(' ')
 				}

--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -796,6 +796,7 @@ func (m *Mattermost) wsActionPostSkip(rmsg *model.WebSocketEvent) bool {
 // maybeShorten returns a prefix of msg that is approximately newLen
 // characters long, followed by "...".  Words that start with uncounted
 // are included in the result but are not reckoned against newLen.
+//
 //nolint:gocyclo
 func maybeShorten(msg string, newLen int, uncounted string, unicode bool) string {
 	if newLen == 0 || len(msg) < newLen {

--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -819,16 +819,13 @@ func maybeShorten(msg string, newLen int, uncounted string, unicode bool) string
 	for i := 0; i <= len(msg); i++ {
 		// Detect word boundaries: space, newline, or end of string
 		if i == len(msg) || msg[i] == ' ' || msg[i] == '\n' { //nolint:nestif
-			// Process the word if we actually captured characters (collapses double spaces/newlines)
+			// Process the extracted word
 			if start < i {
 				word := msg[start:i]
 
-				// Stop if we hit the limit, otherwise add a space
-				if b.Len() > 0 {
-					if b.Len() >= newLen {
-						break
-					}
-					b.WriteByte(' ')
+				// Stop if we hit the limit
+				if b.Len() >= newLen {
+					break
 				}
 
 				// Handle uncounted prefixes and word truncation
@@ -841,6 +838,18 @@ func maybeShorten(msg string, newLen int, uncounted string, unicode bool) string
 				}
 
 				b.WriteString(word)
+			}
+
+			// Explicitly write the delimiters to preserve multiple spaces
+			if i < len(msg) {
+				if b.Len() >= newLen {
+					break
+				}
+				if msg[i] == ' ' {
+					b.WriteByte(' ')
+				} else if msg[i] == '\n' {
+					b.WriteByte(' ')
+				}
 			}
 
 			start = i + 1

--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -809,29 +809,42 @@ func maybeShorten(msg string, newLen int, uncounted string, unicode bool) string
 	}
 
 	var b strings.Builder
-	b.Grow(min(len(msg), newLen+8))
+	// We know len(msg) >= newLen because of the check above,
+	// so we can size the buffer perfectly for the shortened string.
+	b.Grow(newLen + 8)
 
-	fields := strings.FieldsFunc(msg, func(r rune) bool {
-		return r == ' ' || r == '\n'
-	})
+	start := 0
 
-	for _, word := range fields {
-		if b.Len() > 0 {
-			if b.Len() >= newLen {
-				break
+	// Scan the string sequentially just like WrapMessage
+	for i := 0; i <= len(msg); i++ {
+		// Detect word boundaries: space, newline, or end of string
+		if i == len(msg) || msg[i] == ' ' || msg[i] == '\n' {
+			// Process the word if we actually captured characters (collapses double spaces/newlines)
+			if start < i {
+				word := msg[start:i]
+
+				// Stop if we hit the limit, otherwise add a space
+				if b.Len() > 0 {
+					if b.Len() >= newLen {
+						break
+					}
+					b.WriteByte(' ')
+				}
+
+				// Handle uncounted prefixes and word truncation
+				if uncounted != "" && strings.HasPrefix(word, uncounted) {
+					newLen += len(word) + 1
+				} else if len(word) > newLen {
+					// Truncate very long words, but only if they were not skipped, on the
+					// assumption that such words are important enough to be preserved whole.
+					word = word[:newLen*2/3] + "[" + ellipsis + "]"
+				}
+
+				b.WriteString(word)
 			}
-			b.WriteByte(' ')
-		}
 
-		if uncounted != "" && strings.HasPrefix(word, uncounted) {
-			newLen += len(word) + 1
-		} else if len(word) > newLen {
-			// Truncate very long words, but only if they were not skipped, on the
-			// assumption that such words are important enough to be preserved whole.
-			word = word[:newLen*2/3] + "[" + ellipsis + "]"
+			start = i + 1
 		}
-
-		b.WriteString(word)
 	}
 
 	// We also want to reset any formatting which can be carried over from shortening

--- a/mm-go-irckit/channel.go
+++ b/mm-go-irckit/channel.go
@@ -6,8 +6,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/42wim/matterircd/utils"
 	"github.com/mattermost/mattermost-server/v6/model"
-	"github.com/muesli/reflow/wordwrap"
 	"github.com/sorcix/irc"
 )
 
@@ -131,7 +131,7 @@ func (ch *channel) ID() string {
 }
 
 func (ch *channel) Message(from *User, text string) {
-	text = wordwrap.String(text, 440)
+	text = utils.WrapMessage(text, 440)
 
 	msg := irc.Message{
 		Prefix:        from.Prefix(),
@@ -453,9 +453,9 @@ func (ch *channel) Len() int {
 
 func (ch *channel) Spoof(from string, text string, cmd string, maxlen ...int) {
 	if len(maxlen) == 0 {
-		text = wordwrap.String(text, 440)
+		text = utils.WrapMessage(text, 440)
 	} else {
-		text = wordwrap.String(text, maxlen[0])
+		text = utils.WrapMessage(text, maxlen[0])
 	}
 
 	prefix := irc.Prefix{

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -20,7 +20,6 @@ import (
 	"github.com/42wim/matterircd/utils"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/mattermost/mattermost-server/v6/model"
-	"github.com/muesli/reflow/wordwrap"
 	"github.com/sorcix/irc"
 )
 
@@ -219,7 +218,7 @@ func (u *User) handleDirectMessageEvent(event *bridge.DirectMessageEvent) {
 	lexer := ""
 	codeBlockBackTick := false
 	codeBlockTilde := false
-	text = wordwrap.String(text, maxlen)
+	text = utils.WrapMessage(text, maxlen)
 	addPrefix := false
 	for {
 		line, rest, found := strings.Cut(text, "\n")
@@ -420,7 +419,7 @@ func (u *User) handleChannelMessageEvent(event *bridge.ChannelMessageEvent) {
 	lexer := ""
 	codeBlockBackTick := false
 	codeBlockTilde := false
-	text = wordwrap.String(text, maxlen)
+	text = utils.WrapMessage(text, maxlen)
 	addPrefix := false
 	for {
 		line, rest, found := strings.Cut(text, "\n")
@@ -966,9 +965,9 @@ func (u *User) MsgUser(toUser *User, msg string) {
 
 func (u *User) MsgSpoofUser(sender *User, rcvuser string, text string, maxlen ...int) {
 	if len(maxlen) == 0 {
-		text = wordwrap.String(text, 440)
+		text = utils.WrapMessage(text, 440)
 	} else {
-		text = wordwrap.String(text, maxlen[0])
+		text = utils.WrapMessage(text, maxlen[0])
 	}
 
 	prefix := irc.Prefix{

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -77,7 +77,9 @@ func NewUserBridge(c net.Conn, srv Server, cfg *config.Config, db *bolt.DB) *Use
 
 func (u *User) handleEventChan() {
 	for event := range u.eventChan {
-		logger.Tracef("eventchan %s", spew.Sdump(event))
+		if logger.Level.String() == "trace" {
+			logger.Tracef("eventchan %s", spew.Sdump(event))
+		}
 		switch e := event.Data.(type) {
 		case *bridge.ChannelMessageEvent:
 			u.handleChannelMessageEvent(e)

--- a/utils/formatters.go
+++ b/utils/formatters.go
@@ -291,7 +291,11 @@ func EmojiFromAlias(alias string) (string, bool) {
 	return "", false
 }
 
-//nolint:gocognit,gocyclo
+// WrapMessage soft-wraps msg into lines of at most maxLen bytes, breaking
+// only at spaces/newlines. Words longer than maxLen are left unbroken and
+// overflow their line rather than being split - fine here since IRC's real
+// line limit (512) leaves headroom above maxLen (440), and splitting mid-
+// word would corrupt URLs/tokens. Pure byte scanning throughout
 func WrapMessage(msg string, maxLen int) string {
 	if maxLen <= 0 || len(msg) <= maxLen {
 		return msg
@@ -301,61 +305,42 @@ func WrapMessage(msg string, maxLen int) string {
 	b.Grow(len(msg) + (len(msg) / maxLen) * 2)
 
 	lineLen := 0
-	start := 0
+	spaceStart, spaceLen := 0, 0
 
-	for i := 0; i <= len(msg); i++ {
-		// Detect word boundaries: space, newline, tabs or end of string
-		if i == len(msg) || msg[i] == ' ' || msg[i] == '\n' || msg[i] == '\t' { //nolint:nestif
-			// Process the extracted word
-			if start < i {
-				word := msg[start:i]
+	i := 0
+	for i < len(msg) {
+		switch {
+		case msg[i] == ' ' || msg[i] == '\t':
+			spaceStart = i
+			for i < len(msg) && (msg[i] == ' ' || msg[i] == '\t') {
+				i++
+			}
+			spaceLen = i - spaceStart
 
-				// If adding this word exceeds the max. length, wrap to the next line
-				if lineLen > 0 && lineLen+len(word) > maxLen {
-					b.WriteByte('\n')
-					lineLen = 0
-				}
+		case msg[i] == '\n':
+			b.WriteByte('\n')
+			lineLen, spaceLen = 0, 0
+			i++
 
-				// Handle massively long words (like URLs) similar to maybeShorten's truncation
-				for len(word) > maxLen {
-					cut := maxLen
-					// Ensure we don't slice a multi-byte UTF-8 character in half
-					for cut > 0 && (word[cut]&0xC0) == 0x80 {
-						cut--
-					}
-					if cut == 0 {
-						cut = maxLen // Fallback if the string contains invalid UTF-8
-					}
 
-					b.WriteString(word[:cut])
-					b.WriteByte('\n')
-					word = word[cut:]
-					lineLen = 0
-				}
+		default:
+			start := i
+			for i < len(msg) && msg[i] != ' ' && msg[i] != '\t' && msg[i] != '\n' {
+				i++
+			}
+			word := msg[start:i]
 
-				b.WriteString(word)
-				lineLen += len(word)
+			if lineLen > 0 && lineLen+spaceLen+len(word) > maxLen {
+				b.WriteByte('\n')
+				lineLen, spaceLen = 0, 0 // drop pending spaces, don't carry to new line
+			} else if spaceLen > 0 {
+				b.WriteString(msg[spaceStart : spaceStart+spaceLen])
+				lineLen += spaceLen
+				spaceLen = 0
 			}
 
-			// Explicitly preserve the delimiter (spaces and newlines)
-			if i < len(msg) {
-				if msg[i] == ' ' || msg[i] == '\t'{
-					// If the space pushes us over the limit, wrap it
-					if lineLen > 0 && lineLen+1 > maxLen {
-						b.WriteByte('\n')
-						lineLen = 0
-					} else {
-						b.WriteByte(msg[i])
-						lineLen++
-					}
-				} else if msg[i] == '\n' {
-					b.WriteByte('\n')
-					lineLen = 0
-				}
-			}
-
-			// Move the start index past the current boundary character
-			start = i + 1
+			b.WriteString(word)
+			lineLen += len(word)
 		}
 	}
 

--- a/utils/formatters.go
+++ b/utils/formatters.go
@@ -298,14 +298,14 @@ func WrapMessage(msg string, maxLen int) string {
 	}
 
 	var b strings.Builder
-	b.Grow(len(msg) + (len(msg) / maxLen) + 1)
+	b.Grow(len(msg) + (len(msg) / maxLen) * 2)
 
 	lineLen := 0
 	start := 0
 
 	for i := 0; i <= len(msg); i++ {
-		// Detect word boundaries: space, newline, or end of string
-		if i == len(msg) || msg[i] == ' ' || msg[i] == '\n' { //nolint:nestif
+		// Detect word boundaries: space, newline, tabs or end of string
+		if i == len(msg) || msg[i] == ' ' || msg[i] == '\n' || msg[i] == '\t' { //nolint:nestif
 			// Process the extracted word
 			if start < i {
 				word := msg[start:i]
@@ -339,13 +339,13 @@ func WrapMessage(msg string, maxLen int) string {
 
 			// Explicitly preserve the delimiter (spaces and newlines)
 			if i < len(msg) {
-				if msg[i] == ' ' {
+				if msg[i] == ' ' || msg[i] == '\t'{
 					// If the space pushes us over the limit, wrap it
 					if lineLen > 0 && lineLen+1 > maxLen {
 						b.WriteByte('\n')
 						lineLen = 0
 					} else {
-						b.WriteByte(' ')
+						b.WriteByte(msg[i])
 						lineLen++
 					}
 				} else if msg[i] == '\n' {

--- a/utils/formatters.go
+++ b/utils/formatters.go
@@ -296,13 +296,14 @@ func EmojiFromAlias(alias string) (string, bool) {
 // overflow their line rather than being split - fine here since IRC's real
 // line limit (512) leaves headroom above maxLen (440), and splitting mid-
 // word would corrupt URLs/tokens. Pure byte scanning throughout
+//nolint:gocyclo
 func WrapMessage(msg string, maxLen int) string {
 	if maxLen <= 0 || len(msg) <= maxLen {
 		return msg
 	}
 
 	var b strings.Builder
-	b.Grow(len(msg) + (len(msg) / maxLen) * 2)
+	b.Grow(len(msg) + (len(msg)/maxLen)*2)
 
 	lineLen := 0
 	spaceStart, spaceLen := 0, 0
@@ -321,7 +322,6 @@ func WrapMessage(msg string, maxLen int) string {
 			b.WriteByte('\n')
 			lineLen, spaceLen = 0, 0
 			i++
-
 
 		default:
 			start := i

--- a/utils/formatters.go
+++ b/utils/formatters.go
@@ -296,6 +296,7 @@ func EmojiFromAlias(alias string) (string, bool) {
 // overflow their line rather than being split - fine here since IRC's real
 // line limit (512) leaves headroom above maxLen (440), and splitting mid-
 // word would corrupt URLs/tokens. Pure byte scanning throughout
+//
 //nolint:gocyclo
 func WrapMessage(msg string, maxLen int) string {
 	if maxLen <= 0 || len(msg) <= maxLen {

--- a/utils/formatters.go
+++ b/utils/formatters.go
@@ -291,6 +291,7 @@ func EmojiFromAlias(alias string) (string, bool) {
 	return "", false
 }
 
+//nolint:gocognit,gocyclo
 func WrapMessage(msg string, maxLen int) string {
 	if maxLen <= 0 || len(msg) <= maxLen {
 		return msg
@@ -304,7 +305,7 @@ func WrapMessage(msg string, maxLen int) string {
 
 	for i := 0; i <= len(msg); i++ {
 		// Detect word boundaries: space, newline, or end of string
-		if i == len(msg) || msg[i] == ' ' || msg[i] == '\n' {
+		if i == len(msg) || msg[i] == ' ' || msg[i] == '\n' { //nolint:nestif
 			// Process the extracted word
 			if start < i {
 				word := msg[start:i]

--- a/utils/formatters.go
+++ b/utils/formatters.go
@@ -290,3 +290,65 @@ func EmojiFromAlias(alias string) (string, bool) {
 
 	return "", false
 }
+
+func WrapMessage(msg string, maxLen int) string {
+	if maxLen <= 0 || len(msg) <= maxLen {
+		return msg
+	}
+
+	var b strings.Builder
+	b.Grow(len(msg) + (len(msg) / maxLen) + 1)
+
+	lineLen := 0
+	start := 0
+
+	for i := 0; i <= len(msg); i++ {
+		// Detect word boundaries: space, newline, or end of string
+		if i == len(msg) || msg[i] == ' ' || msg[i] == '\n' {
+			// Process the extracted word
+			if start < i {
+				word := msg[start:i]
+
+				// If adding this word exceeds the max. length, wrap to the next line
+				if lineLen > 0 && lineLen+1+len(word) > maxLen {
+					b.WriteByte('\n')
+					lineLen = 0
+				} else if lineLen > 0 {
+					b.WriteByte(' ')
+					lineLen++
+				}
+
+				// Handle massively long words (like URLs) similar to maybeShorten's truncation
+				for len(word) > maxLen {
+					cut := maxLen
+					// Ensure we don't slice a multi-byte UTF-8 character in half
+					for cut > 0 && (word[cut]&0xC0) == 0x80 {
+						cut--
+					}
+					if cut == 0 {
+						cut = maxLen // Fallback if the string contains invalid UTF-8
+					}
+
+					b.WriteString(word[:cut])
+					b.WriteByte('\n')
+					word = word[cut:]
+					lineLen = 0
+				}
+
+				b.WriteString(word)
+				lineLen += len(word)
+			}
+
+			// Preserve intentional newlines from the original message
+			if i < len(msg) && msg[i] == '\n' {
+				b.WriteByte('\n')
+				lineLen = 0
+			}
+
+			// Move the start index past the current boundary character
+			start = i + 1
+		}
+	}
+
+	return b.String()
+}

--- a/utils/formatters.go
+++ b/utils/formatters.go
@@ -311,12 +311,9 @@ func WrapMessage(msg string, maxLen int) string {
 				word := msg[start:i]
 
 				// If adding this word exceeds the max. length, wrap to the next line
-				if lineLen > 0 && lineLen+1+len(word) > maxLen {
+				if lineLen > 0 && lineLen+len(word) > maxLen {
 					b.WriteByte('\n')
 					lineLen = 0
-				} else if lineLen > 0 {
-					b.WriteByte(' ')
-					lineLen++
 				}
 
 				// Handle massively long words (like URLs) similar to maybeShorten's truncation
@@ -340,10 +337,21 @@ func WrapMessage(msg string, maxLen int) string {
 				lineLen += len(word)
 			}
 
-			// Preserve intentional newlines from the original message
-			if i < len(msg) && msg[i] == '\n' {
-				b.WriteByte('\n')
-				lineLen = 0
+			// Explicitly preserve the delimiter (spaces and newlines)
+			if i < len(msg) {
+				if msg[i] == ' ' {
+					// If the space pushes us over the limit, wrap it
+					if lineLen > 0 && lineLen+1 > maxLen {
+						b.WriteByte('\n')
+						lineLen = 0
+					} else {
+						b.WriteByte(' ')
+						lineLen++
+					}
+				} else if msg[i] == '\n' {
+					b.WriteByte('\n')
+					lineLen = 0
+				}
 			}
 
 			// Move the start index past the current boundary character


### PR DESCRIPTION
As part of work for #626.

```
(pprof) tree bytes
Active filters:
   focus=bytes
Showing nodes accounting for 82.07MB, 16.25% of 504.90MB total
----------------------------------------------------------+-------------
      flat  flat%   sum%        cum   cum%   calls calls% + context
----------------------------------------------------------+-------------
                                           59.54MB 96.75% |   github.com/muesli/reflow/ansi.Buffer.PrintableRuneWidth (inline)
                                               1MB  1.63% |   github.com/davecgh/go-spew/spew.Sdump (inline)
                                               1MB  1.62% |   vendor/golang.org/x/net/http2/hpack.(*Decoder).decodeString (inline)
   61.54MB 12.19% 12.19%    61.54MB 12.19%                | bytes.(*Buffer).String
```