### PR TITLE
Reduce memory usage in GetChannelUsers(), GetUsersInTeam(), & UpdateUsers() calls by only storing a reduced user info records

### DIFF
--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -643,15 +643,16 @@ func (m *Mattermost) createUser(mmuser *model.User) *bridge.UserInfo {
 	}
 
 	var realName string
-	if mmuser.FirstName != "" && mmuser.LastName != "" {
+	switch {
+	case mmuser.FirstName != "" && mmuser.LastName != "":
 		realName = mmuser.FirstName + " " + mmuser.LastName
-	} else if mmuser.FirstName != "" {
+	case mmuser.FirstName != "":
 		realName = mmuser.FirstName
-	} else if mmuser.Nickname != "" {
+	case mmuser.Nickname != "":
 		realName = mmuser.Nickname
-	} else if mmuser.LastName != "" {
+	case mmuser.LastName != "":
 		realName = mmuser.LastName
-	} else {
+	default:
 		realName = mmuser.Username
 	}
 

--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -644,8 +644,10 @@ func (m *Mattermost) createUser(mmuser *model.User) *bridge.UserInfo {
 
 	// We only care about mentions for ourselves
 	var mentionKeys []string
-	if keys := mmuser.NotifyProps["mention_keys"]; me && keys != "" {
-		mentionKeys = strings.Split(keys, ",")
+	if me && m.mc.User != nil && m.mc.User.NotifyProps != nil {
+		if keys := m.mc.User.NotifyProps["mention_keys"]; keys != "" {
+			mentionKeys = strings.Split(keys, ",")
+		}
 	}
 
 	info := &bridge.UserInfo{

--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -642,6 +642,19 @@ func (m *Mattermost) createUser(mmuser *model.User) *bridge.UserInfo {
 		teamID = m.mc.Team.ID
 	}
 
+	var realName string
+	if mmuser.FirstName != "" && mmuser.LastName != "" {
+		realName = mmuser.FirstName + " " + mmuser.LastName
+	} else if mmuser.FirstName != "" {
+		realName = mmuser.FirstName
+	} else if mmuser.Nickname != "" {
+		realName = mmuser.Nickname
+	} else if mmuser.LastName != "" {
+		realName = mmuser.LastName
+	} else {
+		realName = mmuser.Username
+	}
+
 	// We only care about mentions for ourselves
 	var mentionKeys []string
 	if me && m.mc.User != nil && m.mc.User.NotifyProps != nil {
@@ -653,7 +666,7 @@ func (m *Mattermost) createUser(mmuser *model.User) *bridge.UserInfo {
 	info := &bridge.UserInfo{
 		Nick:        nick,
 		User:        mmuser.Id,
-		Real:        mmuser.FirstName + " " + mmuser.LastName,
+		Real:        realName,
 		Host:        m.mc.Client.URL,
 		Roles:       mmuser.Roles,
 		Ghost:       true,

--- a/vendor/github.com/matterbridge/matterclient/channels.go
+++ b/vendor/github.com/matterbridge/matterclient/channels.go
@@ -136,11 +136,11 @@ func (m *Client) GetChannelUsers(channelID string) ([]*model.User, error) {
 	}
 	m.Users.mu.RUnlock()
 
-	var allUsers []*model.User
-	idx := 0
 	const batchSize = 200
-	retryCount := 0
+	allUsers := make([]*model.User, 0, batchSize)
 
+	idx := 0
+	retryCount := 0
 	for {
 		query := fmt.Sprintf("/users?in_channel=%v&page=%v&per_page=%v", channelID, idx, batchSize)
 		resp, err := m.Client.DoAPIGet(query, "")
@@ -175,7 +175,6 @@ func (m *Client) GetChannelUsers(channelID string) ([]*model.User, error) {
 				LastName:  u.LastName,
 				Nickname:  u.Nickname,
 				Roles:     u.Roles,
-				Email:     u.Email,
 			})
 		}
 

--- a/vendor/github.com/matterbridge/matterclient/channels.go
+++ b/vendor/github.com/matterbridge/matterclient/channels.go
@@ -1,7 +1,9 @@
 package matterclient
 
 import (
+	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -140,9 +142,14 @@ func (m *Client) GetChannelUsers(channelID string) ([]*model.User, error) {
 	retryCount := 0
 
 	for {
-		mmusersPaged, resp, err := m.Client.GetUsersInChannel(channelID, idx, batchSize, "")
+		query := fmt.Sprintf("/users?in_channel=%v&page=%v&per_page=%v", channelID, idx, batchSize)
+		resp, err := m.Client.DoAPIGet(query, "")
 		if err != nil {
-			shouldRetry, hErr := m.HandleRetry("GetUsersInChannel", retryCount, 10, resp)
+			var mResp *model.Response
+			if resp != nil {
+				mResp = model.BuildResponse(resp)
+			}
+			shouldRetry, hErr := m.HandleRetry("GetUsersInChannel", retryCount, 10, mResp)
 			if hErr == nil && shouldRetry {
 				retryCount++
 				continue
@@ -151,9 +158,28 @@ func (m *Client) GetChannelUsers(channelID string) ([]*model.User, error) {
 		}
 		retryCount = 0
 
-		allUsers = append(allUsers, mmusersPaged...)
+		var list []UserSummary
+		if jsonErr := json.NewDecoder(resp.Body).Decode(&list); jsonErr != nil {
+			resp.Body.Close()
+			return nil, jsonErr
+		}
+		resp.Body.Close()
 
-		if len(mmusersPaged) < batchSize {
+		// Map our lightweight struct back to model.User.
+		// The maps (Props, NotifyProps, etc.) remain nil and take virtually zero memory!
+		for _, u := range list {
+			allUsers = append(allUsers, &model.User{
+				Id:        u.Id,
+				Username:  u.Username,
+				FirstName: u.FirstName,
+				LastName:  u.LastName,
+				Nickname:  u.Nickname,
+				Roles:     u.Roles,
+				Email:     u.Email,
+			})
+		}
+
+		if len(list) < batchSize {
 			break
 		}
 		idx++

--- a/vendor/github.com/matterbridge/matterclient/channels.go
+++ b/vendor/github.com/matterbridge/matterclient/channels.go
@@ -188,7 +188,7 @@ func (m *Client) GetChannelUsers(channelID string) ([]*model.User, error) {
 	defer m.Users.mu.Unlock()
 
 	if m.Users.channels[channelID] == nil {
-		m.Users.channels[channelID] = make(map[string]struct{})
+		m.Users.channels[channelID] = make(map[string]struct{}, len(allUsers))
 	}
 
 	for _, u := range allUsers {

--- a/vendor/github.com/matterbridge/matterclient/matterclient.go
+++ b/vendor/github.com/matterbridge/matterclient/matterclient.go
@@ -132,13 +132,13 @@ func New(login string, pass string, team string, server string, mfatoken string)
 		Credentials:  cred,
 		MessageChan:  make(chan *Message, 100),
 		Users:        &UsersCache{
-			users:    make(map[string]*model.User),
-			channels: make(map[string]map[string]struct{}),
-			teams:    make(map[string]map[string]struct{}),
-			statuses: make(map[string]string),
+			users:    make(map[string]*model.User, 1000),
+			channels: make(map[string]map[string]struct{}, 1000),
+			teams:    make(map[string]map[string]struct{}, 10),
+			statuses: make(map[string]string, 1000),
 
-			channelData:    make(map[string]*model.Channel),
-			joinedChannels: make(map[string]struct{}),
+			channelData:    make(map[string]*model.Channel, 1000),
+			joinedChannels: make(map[string]struct{}, 200),
 		},
 		rootLogger:   rootLogger,
 		lruCache:     cache,
@@ -163,7 +163,7 @@ func (m *Client) Login() error {
 			m.logger.Info("reconnect: flushing channel user cache to ensure state consistency")
 
 			m.Users.mu.Lock()
-			m.Users.channels = make(map[string]map[string]struct{})
+			m.Users.channels = make(map[string]map[string]struct{}, 1000)
 			m.Users.mu.Unlock()
 
 			m.Users.lastUpdated.Store(time.Now().Unix())
@@ -419,7 +419,7 @@ func (m *Client) initUser() error {
 		m.logger.Debugf("fetching users for team %s (cache expired or missing)", team.Name)
 
 		idx := 0
-		var teamUsers []*model.User
+		teamUsers :=  make([]*model.User, 0, batchSize)
 		pageRetryCount := 0
 
 		for {

--- a/vendor/github.com/matterbridge/matterclient/matterclient.go
+++ b/vendor/github.com/matterbridge/matterclient/matterclient.go
@@ -38,7 +38,7 @@ type Credentials struct {
 }
 
 type UsersCache struct {
-	mu sync.RWMutex
+	mu       sync.RWMutex
 	users    map[string]*model.User
 	channels map[string]map[string]struct{}
 	teams    map[string]map[string]struct{}
@@ -48,6 +48,16 @@ type UsersCache struct {
 	joinedChannels map[string]struct{}
 
 	lastUpdated atomic.Int64
+}
+
+type UserSummary struct {
+        Id        string `json:"id"`
+        Username  string `json:"username"`
+        FirstName string `json:"first_name"`
+        LastName  string `json:"last_name"`
+        Nickname  string `json:"nickname"`
+        Roles     string `json:"roles"`
+        Email     string `json:"email"`
 }
 
 type Team struct {

--- a/vendor/github.com/matterbridge/matterclient/matterclient.go
+++ b/vendor/github.com/matterbridge/matterclient/matterclient.go
@@ -419,13 +419,18 @@ func (m *Client) initUser() error {
 		m.logger.Debugf("fetching users for team %s (cache expired or missing)", team.Name)
 
 		idx := 0
-		teamUsers :=  make([]*model.User, 0, batchSize)
+		teamUsers := make([]*model.User, 0, batchSize)
 		pageRetryCount := 0
 
 		for {
-			mmusers, resp, err := m.Client.GetUsersInTeam(team.Id, idx, batchSize, "")
+			query := fmt.Sprintf("/users?in_team=%v&page=%v&per_page=%v", team.Id, idx, batchSize)
+			resp, err := m.Client.DoAPIGet(query, "")
 			if err != nil {
-				shouldRetry, hErr := m.HandleRetry("GetUsersInTeam", pageRetryCount, 10, resp)
+				var mResp *model.Response
+				if resp != nil {
+					mResp = model.BuildResponse(resp)
+				}
+				shouldRetry, hErr := m.HandleRetry("GetUsersInTeam", pageRetryCount, 10, mResp)
 				if hErr == nil && shouldRetry {
 					pageRetryCount++
 					continue
@@ -435,9 +440,27 @@ func (m *Client) initUser() error {
 			}
 			pageRetryCount = 0
 
-			teamUsers = append(teamUsers, mmusers...)
+			// Decode into our lightweight struct, completely ignoring heavy maps!
+			var list []UserSummary
+			if jsonErr := json.NewDecoder(resp.Body).Decode(&list); jsonErr != nil {
+				resp.Body.Close()
+				return jsonErr
+			}
+			resp.Body.Close()
 
-			if len(mmusers) < batchSize {
+			// Map back to standard model.User
+			for _, u := range list {
+				teamUsers = append(teamUsers, &model.User{
+					Id:        u.Id,
+					Username:  u.Username,
+					FirstName: u.FirstName,
+					LastName:  u.LastName,
+					Nickname:  u.Nickname,
+					Roles:     u.Roles,
+				})
+			}
+
+			if len(list) < batchSize {
 				break
 			}
 
@@ -450,7 +473,7 @@ func (m *Client) initUser() error {
 		if m.Users.teams == nil {
 			m.Users.teams = make(map[string]map[string]struct{})
 		}
-		m.Users.teams[team.Id] = make(map[string]struct{})
+		m.Users.teams[team.Id] = make(map[string]struct{}, len(teamUsers))
 		for _, u := range teamUsers {
 			m.Users.users[u.Id] = u
 			m.Users.teams[team.Id][u.Id] = struct{}{}

--- a/vendor/github.com/matterbridge/matterclient/matterclient.go
+++ b/vendor/github.com/matterbridge/matterclient/matterclient.go
@@ -57,7 +57,6 @@ type UserSummary struct {
         LastName  string `json:"last_name"`
         Nickname  string `json:"nickname"`
         Roles     string `json:"roles"`
-        Email     string `json:"email"`
 }
 
 type Team struct {

--- a/vendor/github.com/matterbridge/matterclient/users.go
+++ b/vendor/github.com/matterbridge/matterclient/users.go
@@ -1,6 +1,7 @@
 package matterclient
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -156,31 +157,50 @@ func (m *Client) SetUserStatus(userID string, rawStatus string) string {
 
 func (m *Client) UpdateUsers() error {
 	const batchSize = 200
+
 	idx := 0
 	retryCount := 0
-
 	for {
-		mmusers, resp, err := m.Client.GetUsers(idx, batchSize, "")
+		query := fmt.Sprintf("/users?page=%v&per_page=%v", idx, batchSize)
+		resp, err := m.Client.DoAPIGet(query, "")
 		if err != nil {
-			shouldRetry, hErr := m.HandleRetry("GetUsers", retryCount, 10, resp)
+			var mResp *model.Response
+			if resp != nil {
+				mResp = model.BuildResponse(resp)
+			}
+			shouldRetry, hErr := m.HandleRetry("GetUsers", retryCount, 10, mResp)
 			if hErr == nil && shouldRetry {
 				retryCount++
 				continue
 			}
-
 			m.logger.Errorf("UpdateUsers failed at batch %d: %v", idx, err)
 			return err
 		}
 		retryCount = 0
 
+		var list []UserSummary
+		if jsonErr := json.NewDecoder(resp.Body).Decode(&list); jsonErr != nil {
+			resp.Body.Close()
+			return jsonErr
+		}
+		resp.Body.Close()
+
 		m.Users.mu.Lock()
-		for _, user := range mmusers {
-			m.Users.users[user.Id] = user
+		for _, u := range list {
+			// Convert directly into the cache to avoid maps
+			m.Users.users[u.Id] = &model.User{
+				Id:        u.Id,
+				Username:  u.Username,
+				FirstName: u.FirstName,
+				LastName:  u.LastName,
+				Nickname:  u.Nickname,
+				Roles:     u.Roles,
+			}
 		}
 		m.Users.lastUpdated.Store(time.Now().Unix())
 		m.Users.mu.Unlock()
 
-		if len(mmusers) < batchSize {
+		if len(list) < batchSize {
 			break
 		}
 
@@ -222,7 +242,7 @@ func (m *Client) UsernamesInChannel(channelID string) []string {
 	}
 
 	allusers := m.GetUsers()
-	result := []string{}
+	result := make([]string, 0, 1000)
 
 	for _, member := range res {
 		result = append(result, allusers[member.UserId].Nickname)


### PR DESCRIPTION
As part of work for #626.