### PR TITLE
Reduce memory allocs in CmdWho, CmdNames & SendNamesResponse

### DIFF
--- a/mm-go-irckit/channel.go
+++ b/mm-go-irckit/channel.go
@@ -288,45 +288,55 @@ func (ch *channel) SendNamesResponse(u *User) error {
 		return u.Encode(end)
 	}
 
-	msgs := make([]*irc.Message, 0, len(names)+1)
+	estimatedMsgs := (len(names) / 20) + 2
+	messages := make([]irc.Message, 0, estimatedMsgs)
+	sharedNamReplyParams := []string{u.Nick, "=", ch.name}
 
 	var line strings.Builder
 	line.Grow(512)
 	i := 0
 	for _, name := range names {
-		if i+len(name) < 400 {
+		nameLen := len(name) + 1
+		if i+nameLen < 400 {
 			line.WriteString(name)
 			line.WriteByte(' ')
-			i += len(name)
+			i += nameLen
 		} else {
-			msgs = append(msgs, &irc.Message{
+			messages = append(messages, irc.Message{
 				Prefix:   prefix,
 				Command:  irc.RPL_NAMREPLY,
-				Params:   []string{u.Nick, "=", ch.name},
+				Params:   sharedNamReplyParams,
 				Trailing: line.String(),
 			})
 			line.Reset()
 			line.WriteString(name)
 			line.WriteByte(' ')
-			i = len(name)
+			i = nameLen
 		}
 	}
 
-	msgs = append(msgs, &irc.Message{
-		Prefix:   prefix,
-		Command:  irc.RPL_NAMREPLY,
-		Params:   []string{u.Nick, "=", ch.name},
-		Trailing: line.String(),
-	})
+	if line.Len() > 0 {
+		messages = append(messages, irc.Message{
+			Prefix:   prefix,
+			Command:  irc.RPL_NAMREPLY,
+			Params:   sharedNamReplyParams,
+			Trailing: line.String(),
+		})
+	}
 
-	msgs = append(msgs, &irc.Message{
+	messages = append(messages, irc.Message{
 		Prefix:   prefix,
 		Params:   []string{u.Nick, ch.name},
 		Command:  irc.RPL_ENDOFNAMES,
 		Trailing: "End of /NAMES list.",
 	})
 
-	return u.Encode(msgs...)
+	r := make([]*irc.Message, len(messages))
+	for j := range messages {
+		r[j] = &messages[j]
+	}
+
+	return u.Encode(r...)
 }
 
 func (ch *channel) BatchJoin(inputusers []*User) error {

--- a/mm-go-irckit/server_commands.go
+++ b/mm-go-irckit/server_commands.go
@@ -250,12 +250,21 @@ func CmdNames(s Server, u *User, msg *irc.Message) error {
 		return nil
 	}
 
-	for _, channel := range strings.Split(msg.Params[0], ",") {
-		ch, exists := s.HasChannel(channel)
-		if !exists {
-			continue
+	channels := msg.Params[0]
+	for len(channels) > 0 {
+		var channel string
+		idx := strings.IndexByte(channels, ',')
+		if idx < 0 {
+			channel = channels
+			channels = ""
+		} else {
+			channel = channels[:idx]
+			channels = channels[idx+1:]
 		}
-		ch.SendNamesResponse(u)
+
+		if ch, exists := s.HasChannel(channel); exists {
+			ch.SendNamesResponse(u)
+		}
 	}
 	return nil
 }

--- a/mm-go-irckit/server_commands.go
+++ b/mm-go-irckit/server_commands.go
@@ -725,30 +725,51 @@ func CmdWho(s Server, u *User, msg *irc.Message) error {
 		return nil
 	}
 
-	r := make([]*irc.Message, 0, ch.Len()+1)
+	users := ch.Users()
+	numUsers := len(users)
+
+	r := make([]*irc.Message, numUsers+1)
+	messages := make([]irc.Message, numUsers+1)
+	paramsBacking := make([]string, numUsers*7)
 
 	statuses, _ := u.br.StatusUsers()
 
-	for _, other := range ch.Users() {
+	prefix := s.Prefix()
+	myNick := u.Nick
+	for i, other := range users {
 		status := "H"
 		if statuses[other.User] != "online" {
 			status = "G"
 		}
+
+		pIdx := i * 7
+		params := paramsBacking[pIdx : pIdx+7 : pIdx+7]
+		params[0] = myNick
+		params[1] = mask
+		params[2] = other.User
+		params[3] = other.Host
+		params[4] = "*"
+		params[5] = other.Nick
+		params[6] = status
+
 		// <me> <channel> <user> <host> <server> <nick> [H/G]: 0 <real>
-		r = append(r, &irc.Message{
-			Prefix:   s.Prefix(),
-			Params:   []string{u.Nick, mask, other.User, other.Host, "*", other.Nick, status},
+		messages[i] = irc.Message{
+			Prefix:   prefix,
+			Params:   params,
 			Command:  irc.RPL_WHOREPLY,
 			Trailing: "0 " + other.Real,
-		})
+		}
+
+		r[i] = &messages[i]
 	}
 
-	r = append(r, &irc.Message{
-		Prefix:   s.Prefix(),
-		Params:   []string{u.Nick, mask},
+	messages[numUsers] = irc.Message{
+		Prefix:   prefix,
+		Params:   []string{myNick, mask},
 		Command:  irc.RPL_ENDOFWHO,
 		Trailing: "End of /WHO list.",
-	})
+	}
+	r[numUsers] = &messages[numUsers]
 
 	return u.Encode(r...)
 }

--- a/mm-go-irckit/server_commands.go
+++ b/mm-go-irckit/server_commands.go
@@ -263,7 +263,7 @@ func CmdNames(s Server, u *User, msg *irc.Message) error {
 		}
 
 		if ch, exists := s.HasChannel(channel); exists {
-			ch.SendNamesResponse(u)
+			_ = ch.SendNamesResponse(u)
 		}
 	}
 	return nil


### PR DESCRIPTION
As part of work for #626.