### PR TITLE
Fix missing strconv.Unquote for formatting chars by moving it to a central place on config load

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -416,13 +416,13 @@ func SetLogLevel(level logrus.Level) {
 }
 
 func unquoteString(s string) string {
-        if s == "" || !strings.ContainsRune(s, '\\') {
-                return s
-        }
-        if unq, err := strconv.Unquote(`"` + s + `"`); err == nil {
-                return unq
-        }
-        return s
+	if s == "" || !strings.ContainsRune(s, '\\') {
+		return s
+	}
+	if unq, err := strconv.Unquote(`"` + s + `"`); err == nil {
+		return unq
+	}
+	return s
 }
 
 func validate(runtimeCfg *RuntimeConfig) error {

--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -206,11 +207,11 @@ func (c *Config) buildRuntimeCfg() *RuntimeConfig {
 
 		DisableMarkdown:           c.v.GetBool("mattermost.DisableMarkdown"),
 		DisableMarkdownBlockQuote: c.v.GetBool("mattermost.DisableMarkdownBlockQuote"),
-		MarkdownBlockQuoteChar:    c.v.GetString("mattermost.MarkdownBlockQuoteChar"),
-		MarkdownInlineCode:        c.v.GetString("mattermost.MarkdownInlineCode"),
+		MarkdownBlockQuoteChar:    unquoteString(c.v.GetString("mattermost.MarkdownBlockQuoteChar")),
+		MarkdownInlineCode:        unquoteString(c.v.GetString("mattermost.MarkdownInlineCode")),
 
 		DisableCodeBlockPrefix: c.v.GetBool("mattermost.DisableCodeBlockPrefix"),
-		CodeBlockPrefix:        c.v.GetString("mattermost.CodeBlockPrefix"),
+		CodeBlockPrefix:        unquoteString(c.v.GetString("mattermost.CodeBlockPrefix")),
 		SyntaxHighlighting:     c.v.GetString("mattermost.SyntaxHighlighting"),
 
 		Unicode: c.v.GetBool("mattermost.Unicode"),
@@ -220,11 +221,11 @@ func (c *Config) buildRuntimeCfg() *RuntimeConfig {
 
 		DisableMarkdown:           c.v.GetBool("slack.DisableMarkdown"),
 		DisableMarkdownBlockQuote: c.v.GetBool("slack.DisableMarkdownBlockQuote"),
-		MarkdownBlockQuoteChar:    c.v.GetString("slack.MarkdownBlockQuoteChar"),
-		MarkdownInlineCode:        c.v.GetString("slack.MarkdownInlineCode"),
+		MarkdownBlockQuoteChar:    unquoteString(c.v.GetString("slack.MarkdownBlockQuoteChar")),
+		MarkdownInlineCode:        unquoteString(c.v.GetString("slack.MarkdownInlineCode")),
 
 		DisableCodeBlockPrefix: c.v.GetBool("slack.DisableCodeBlockPrefix"),
-		CodeBlockPrefix:        c.v.GetString("slack.CodeBlockPrefix"),
+		CodeBlockPrefix:        unquoteString(c.v.GetString("slack.CodeBlockPrefix")),
 		SyntaxHighlighting:     c.v.GetString("slack.SyntaxHighlighting"),
 
 		Unicode: c.v.GetBool("slack.Unicode"),
@@ -234,11 +235,11 @@ func (c *Config) buildRuntimeCfg() *RuntimeConfig {
 
 		DisableMarkdown:           c.v.GetBool("mastodon.DisableMarkdown"),
 		DisableMarkdownBlockQuote: c.v.GetBool("mastodon.DisableMarkdownBlockQuote"),
-		MarkdownBlockQuoteChar:    c.v.GetString("mastodon.MarkdownBlockQuoteChar"),
-		MarkdownInlineCode:        c.v.GetString("mastodon.MarkdownInlineCode"),
+		MarkdownBlockQuoteChar:    unquoteString(c.v.GetString("mastodon.MarkdownBlockQuoteChar")),
+		MarkdownInlineCode:        unquoteString(c.v.GetString("mastodon.MarkdownInlineCode")),
 
 		DisableCodeBlockPrefix: c.v.GetBool("mastodon.DisableCodeBlockPrefix"),
-		CodeBlockPrefix:        c.v.GetString("mastodon.CodeBlockPrefix"),
+		CodeBlockPrefix:        unquoteString(c.v.GetString("mastodon.CodeBlockPrefix")),
 		SyntaxHighlighting:     c.v.GetString("mastodon.SyntaxHighlighting"),
 
 		Unicode: c.v.GetBool("mastodon.Unicode"),
@@ -412,6 +413,16 @@ func SetLogLevel(level logrus.Level) {
 	if logger != nil {
 		logger.Logger.SetLevel(level)
 	}
+}
+
+func unquoteString(s string) string {
+        if s == "" || !strings.ContainsRune(s, '\\') {
+                return s
+        }
+        if unq, err := strconv.Unquote(`"` + s + `"`); err == nil {
+                return unq
+        }
+        return s
 }
 
 func validate(runtimeCfg *RuntimeConfig) error {

--- a/utils/formatters.go
+++ b/utils/formatters.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"bytes"
-	"strconv"
 	"strings"
 	"sync"
 
@@ -12,12 +11,6 @@ import (
 
 //nolint:funlen,gocyclo
 func FormatCodeBlockText(text string, codeBlockBackTick bool, codeBlockTilde bool, lexer string, syntaxHighlighting string, linePrefix string) (string, bool, bool, string) {
-	if linePrefix != "" && strings.ContainsRune(linePrefix, '\\') {
-		if unq, err := strconv.Unquote(`"` + linePrefix + `"`); err == nil {
-			linePrefix = unq
-		}
-	}
-
 	trimmedText := strings.TrimLeft(text, " \t")
 
 	// Inline backtick toggle logic to avoid closure allocations
@@ -286,9 +279,6 @@ func Markdown2irc(msg string, blockQuoteChar string, inlineCode string) string {
 		inlineCodeEnd := "\x11\x0f`"
 
 		if inlineCode != "" {
-			if unq, err := strconv.Unquote(`"` + inlineCode + `"`); err == nil {
-				inlineCode = unq
-			}
 			inlineCodeStart = inlineCode
 			// Remove fence if not present
 			if !strings.Contains(inlineCode, "`") {
@@ -302,10 +292,6 @@ func Markdown2irc(msg string, blockQuoteChar string, inlineCode string) string {
 	// Block quotes
 	trimmedText := strings.TrimLeft(msg, " \t")
 	if strings.HasPrefix(trimmedText, blockQuoteCharDefault) && blockQuoteChar != blockQuoteCharDefault {
-		if unq, err := strconv.Unquote(`"` + blockQuoteChar + `"`); err == nil {
-			blockQuoteChar = unq
-		}
-
 		var newPrefix strings.Builder
 		idx := 0
 	ParseLoop:


### PR DESCRIPTION
Fixes places where we missed this such as `getMarkdownBlockCodePrefix()` in `mm-go-irckit/userbridge.go`. We move it to a central place on config load which reduces all that duplication.