### PR TITLE
Add option to enable profiling (Go pprof)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -42,9 +42,10 @@ type RuntimeConfig struct {
 type GlobalConfig struct {
 	Bind string
 
-	Debug bool
-	Trace bool
-	Gops  bool
+	Debug     bool
+	Trace     bool
+	Gops      bool
+	Profiling bool
 
 	TLSBind string
 	TLSDir  string
@@ -249,9 +250,10 @@ func (c *Config) buildRuntimeCfg() *RuntimeConfig {
 		GlobalConfig: GlobalConfig{
 			Bind: c.v.GetString("bind"),
 
-			Debug: c.v.GetBool("debug"),
-			Trace: c.v.GetBool("trace"),
-			Gops:  c.v.GetBool("gops"),
+			Debug:     c.v.GetBool("debug"),
+			Trace:     c.v.GetBool("trace"),
+			Gops:      c.v.GetBool("gops"),
+			Profiling: c.v.GetBool("profiling"),
 
 			TLSBind: c.v.GetString("tlsbind"),
 			TLSDir:  c.v.GetString("tlsdir"),

--- a/main.go
+++ b/main.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"net/http"
 	"os"
+	"runtime"
 	"strings"
 	"time"
 
@@ -18,6 +20,8 @@ import (
 	prefixed "github.com/matterbridge/logrus-prefixed-formatter"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
+
+	_ "net/http/pprof" //nolint:gosec
 )
 
 var (
@@ -33,6 +37,7 @@ func main() {
 	ourlog := logrus.New()
 	ourlog.Formatter = &prefixed.TextFormatter{
 		PrefixPadding: 11,
+		DisableColors: false,
 		FullTimestamp: true,
 	}
 	logger = ourlog.WithFields(logrus.Fields{"prefix": "matterircd"})
@@ -79,6 +84,25 @@ func main() {
 		if err := agent.Listen(agent.Options{}); err != nil {
 			log.Fatal(err)
 		}
+	}
+
+	if rc.Profiling {
+		runtime.SetBlockProfileRate(1)
+		runtime.SetMutexProfileFraction(10)
+		go func() {
+			logger.Infof("enabling profiling: start HTTP server: *:6060")
+
+			h := http.DefaultServeMux
+			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Remove any gzip (or other content-encoding) header.
+				w.Header().Del("Content-Encoding")
+				h.ServeHTTP(w, r)
+			})
+
+			if err := http.ListenAndServe(":6060", handler); err != nil { //nolint:gosec
+				logger.Fatal("profiling: Failed to start HTTP server", err)
+			}
+		}()
 	}
 
 	if flag.Lookup("version").Value.String() == "true" {


### PR DESCRIPTION
This inflates the binary by about 860KBytes, but I think it's worth it.

Compiled with Go 1.26.

Before:

```
-rwxr-xr-x 1 hloeung hloeung 21403586 Jul 31 06:31 matterircd
```

After:

```
-rwxr-xr-x 1 hloeung hloeung 22262662 Jul 31 06:31 matterircd
```
