### PR TITLE
Include +i invite-only for channel modes

### DIFF
--- a/mm-go-irckit/server.go
+++ b/mm-go-irckit/server.go
@@ -367,7 +367,7 @@ func (s *server) welcome(u *User) error {
 		&irc.Message{
 			Prefix:   s.Prefix(),
 			Command:  irc.RPL_ISUPPORT,
-			Params:   []string{u.Nick, "CHANMODES=b,k,l,ps", "PREFIX=(ov)@+", "NETWORK=matterircd"},
+			Params:   []string{u.Nick, "CHANMODES=b,k,l,ips", "PREFIX=(ov)@+", "NETWORK=matterircd"},
 			Trailing: "are supported by this server",
 		},
 		&irc.Message{

--- a/mm-go-irckit/server_commands.go
+++ b/mm-go-irckit/server_commands.go
@@ -251,7 +251,7 @@ func CmdMode(s Server, u *User, msg *irc.Message) error {
 
 	mode := "+"
 	if s.Channel(channel).IsPrivate() {
-		mode = "+p"
+		mode = "+pi"
 	}
 
 	r := []*irc.Message{}


### PR DESCRIPTION
For Mattermost private channels, users can't join without being invited so seems more correct to me to add +i / invite-only to the channel mode to indicate so.

Continuing on https://github.com/42wim/matterircd/pull/789