### PR TITLE
Fix crash in doCheckAlive()

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/kenshaw/emoji v0.6.2
 	github.com/matterbridge/logrus-prefixed-formatter v0.5.3-0.20200523233437-d971309a77ba
-	github.com/matterbridge/matterclient v0.0.0-20260819210359-cfd5ef9e6dc1
+	github.com/matterbridge/matterclient v0.0.0-20260820220716-02d30983d136
 	github.com/mattermost/mattermost/server/public v0.1.3
 	github.com/mattn/go-mastodon v0.0.6
 	github.com/mitchellh/mapstructure v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -238,8 +238,8 @@ github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3v
 github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/matterbridge/logrus-prefixed-formatter v0.5.3-0.20200523233437-d971309a77ba h1:XleOY4IjAEIcxAh+IFwT5JT5Ze3RHiYz6m+4ZfZ0rc0=
 github.com/matterbridge/logrus-prefixed-formatter v0.5.3-0.20200523233437-d971309a77ba/go.mod h1:iXGEotOvwI1R1SjLxRc+BF5rUORTMtE0iMZBT2lxqAU=
-github.com/matterbridge/matterclient v0.0.0-20260819210359-cfd5ef9e6dc1 h1:KaGUDPZYazNaCv9pPBkx12D6E5jD/O9OcBw9s9mbFNQ=
-github.com/matterbridge/matterclient v0.0.0-20260819210359-cfd5ef9e6dc1/go.mod h1:5+Z8FKATFPNAzp702walUDWmWo+7FruwxQS1vgE0o6s=
+github.com/matterbridge/matterclient v0.0.0-20260820220716-02d30983d136 h1:daxC9oG7rtv5wKpiXVXROx8f0aGODScO0gaFpP4TkRA=
+github.com/matterbridge/matterclient v0.0.0-20260820220716-02d30983d136/go.mod h1:5+Z8FKATFPNAzp702walUDWmWo+7FruwxQS1vgE0o6s=
 github.com/mattermost/go-i18n v1.11.1-0.20211013152124-5c415071e404 h1:Khvh6waxG1cHc4Cz5ef9n3XVCxRWpAKUtqg9PJl5+y8=
 github.com/mattermost/go-i18n v1.11.1-0.20211013152124-5c415071e404/go.mod h1:RyS7FDNQlzF1PsjbJWHRI35exqaKGSO9qD4iv8QjE34=
 github.com/mattermost/ldap v0.0.0-20231116144001-0f480c025956 h1:Y1Tu/swM31pVwwb2BTCsOdamENjjWCI6qmfHLbk6OZI=

--- a/vendor/github.com/matterbridge/matterclient/matterclient.go
+++ b/vendor/github.com/matterbridge/matterclient/matterclient.go
@@ -947,7 +947,14 @@ func (m *Client) wsConnect(ctx context.Context) {
 	m.WsConnected = true
 }
 
-func (m *Client) doCheckAlive(ctx context.Context) error {
+//nolint:funcorder
+func (m *Client) doCheckAlive(ctx context.Context) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("websocket ping panic (connection closed): %v", r)
+		}
+	}()
+
 	if m.WsClient != nil && m.WsClient.ListenError != nil {
 		return fmt.Errorf("websocket listen error: %w", m.WsClient.ListenError)
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -112,7 +112,7 @@ github.com/magiconair/properties
 # github.com/matterbridge/logrus-prefixed-formatter v0.5.3-0.20200523233437-d971309a77ba
 ## explicit
 github.com/matterbridge/logrus-prefixed-formatter
-# github.com/matterbridge/matterclient v0.0.0-20260819210359-cfd5ef9e6dc1
+# github.com/matterbridge/matterclient v0.0.0-20260820220716-02d30983d136
 ## explicit; go 1.21
 github.com/matterbridge/matterclient
 # github.com/mattermost/go-i18n v1.11.1-0.20211013152124-5c415071e404


### PR DESCRIPTION
```
[2026-08-20T21:44:19Z]  WARN matterclient: Transient error 504 on ViewChannel, backing off: 1s (attempt 1/10)
[2026-08-20T21:45:21Z]  WARN matterclient: Transient error 504 on ViewChannel, backing off: 2s (attempt 2/10)
[2026-08-20T21:46:23Z]  WARN matterclient: Transient error 504 on ViewChannel, backing off: 3s (attempt 3/10)
panic: send on closed channel

goroutine 1163 [running]:
github.com/mattermost/mattermost/server/public/model.(*WebSocketClient).SendMessage(...)
        /home/hloeung/development/matterircd/vendor/github.com/mattermost/mattermost/server/public/model/websocket_client.go:278
github.com/matterbridge/matterclient.(*Client).doCheckAlive(0x2a53e0da480, {0x14e9760, 0x2a53e812280})
        /home/hloeung/development/matterircd/vendor/github.com/matterbridge/matterclient/matterclient.go:970 +0x285
github.com/matterbridge/matterclient.(*Client).checkAlive(0x2a53e0da480, {0x14e9760, 0x2a53e812280})
        /home/hloeung/development/matterircd/vendor/github.com/matterbridge/matterclient/matterclient.go:1002 +0x12f
created by github.com/matterbridge/matterclient.(*Client).checkConnection in goroutine 1118
        /home/hloeung/development/matterircd/vendor/github.com/matterbridge/matterclient/matterclient.go:1030 +0x98

```