### PR TITLE
Split out LazyJoin exemptions from JoinInclude to LazyJoinExclude

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -154,6 +154,7 @@ type MattermostConfig struct {
 	LastViewedSaveFile   string
 	ReplayStrategy       string
 	EnableLazyJoin       bool
+	LazyJoinExclude      []string
 	ForceSyncOnReconnect bool
 
 	MaxReplayDuration         time.Duration
@@ -366,6 +367,7 @@ func (c *Config) buildRuntimeCfg() *RuntimeConfig {
 			LastViewedSaveFile:   c.v.GetString("mattermost.LastViewedSaveFile"),
 			ReplayStrategy:       c.v.GetString("mattermost.ReplayStrategy"),
 			EnableLazyJoin:       c.v.GetBool("mattermost.EnableLazyJoin"),
+			LazyJoinExclude:      append([]string(nil), c.v.GetStringSlice("mattermost.LazyJoinExclude")...),
 			ForceSyncOnReconnect: c.v.GetBool("mattermost.ForceSyncOnReconnect"),
 
 			MaxReplayDuration:         c.v.GetDuration("mattermost.MaxReplayDuration"),

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -1307,11 +1307,10 @@ func (u *User) addUserToChannelWorker(channels <-chan *bridge.ChannelInfo, throt
 			since, sinceStr, inDB := u.getChannelSince(u.ctx, brchannel, replayCutoff)
 			isDM := u.br.IsDMChannelName(brchannel.Name)
 
-			// Determine if this channel is explicitly whitelisted in the config
+			// Determine if this channel is explicitly whitelisted to bypass LazyJoin
 			chName := u.Srv.Channel(brchannel.ID).String()
-			jo := u.br.BridgeConfig().JoinOnly
-			ji := u.br.BridgeConfig().JoinInclude
-			isWhitelisted := (len(jo) > 0 && stringInRegexp(chName, jo)) || (len(ji) > 0 && stringInRegexp(chName, ji))
+			lje := u.cfg.Mattermost().LazyJoinExclude
+			isWhitelisted := len(lje) > 0 && stringInRegexp(chName, lje)
 
 			// If Lazy-Join is enabled AND replay strategy is "saved", ONLY join channels already known in
 			// the last saved DB. If Lazy-Join is disabled, joins all channels user is member of!


### PR DESCRIPTION
Following on the changes in https://github.com/42wim/matterircd/pull/818