### PR TITLE
Fix race where modifying/deleting wrong last sent message

### DIFF
--- a/mm-go-irckit/server_commands.go
+++ b/mm-go-irckit/server_commands.go
@@ -537,6 +537,10 @@ func CmdPrivMsg(s Server, u *User, msg *irc.Message) error {
 			return nil
 		}
 
+		targetLock := u.getMsgChanLock(ch.ID())
+		targetLock.Lock()
+		defer targetLock.Unlock()
+
 		if parseReactionToMsg(u, msg, ch.ID()) {
 			return nil
 		}
@@ -556,8 +560,8 @@ func CmdPrivMsg(s Server, u *User, msg *irc.Message) error {
 		}
 
 		u.msgLastMutex.Lock()
-		defer u.msgLastMutex.Unlock()
 		u.msgLast[ch.ID()] = [2]string{msgID, ""}
+		u.msgLastMutex.Unlock()
 		u.saveLastViewedAt(ch.ID())
 
 		if u.br.BridgeConfig().PrefixContext || u.br.BridgeConfig().SuffixContext {
@@ -581,6 +585,10 @@ func CmdPrivMsg(s Server, u *User, msg *irc.Message) error {
 				return nil
 			}
 
+			targetLock := u.getMsgChanLock(toUser.User)
+			targetLock.Lock()
+			defer targetLock.Unlock()
+
 			if parseReactionToMsg(u, msg, toUser.User) {
 				logger.Trace("matched parseReactionToMsg")
 				return nil
@@ -601,9 +609,10 @@ func CmdPrivMsg(s Server, u *User, msg *irc.Message) error {
 				u.MsgSpoofUser(u, u.br.Protocol(), "msg: "+msg.Trailing+" could not be sent "+err2.Error())
 				return err2
 			}
+
 			u.msgLastMutex.Lock()
-			defer u.msgLastMutex.Unlock()
 			u.msgLast[toUser.User] = [2]string{msgID, ""}
+			u.msgLastMutex.Unlock()
 			u.saveLastViewedAt(u.br.GetChannelID(u.ctx, toUser.User, ""))
 
 			if u.br.BridgeConfig().PrefixContext || u.br.BridgeConfig().SuffixContext {

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -40,9 +40,11 @@ type UserBridge struct {
 	eventLoopMutex   sync.Mutex
 	eventLoopStarted bool
 
+	lastEventTime  atomic.Int64
 	lastViewedAtDB *bolt.DB
 
-	lastEventTime atomic.Int64
+	msgChanLockMutex sync.Mutex
+	msgChanLocks     map[string]*sync.Mutex
 
 	msgCounterMutex sync.RWMutex
 	msgCounter      map[string]int
@@ -71,6 +73,8 @@ func NewUserBridge(c net.Conn, srv Server, cfg *config.Config, db *bolt.DB) *Use
 	u.Srv = srv
 	u.cfg = cfg
 	u.lastViewedAtDB = db
+
+	u.msgChanLocks = make(map[string]*sync.Mutex)
 	u.msgLast = make(map[string][2]string)
 	u.msgMap = make(map[string]map[string]int)
 	u.msgMapIndex = make(map[string]map[int]string)
@@ -2185,4 +2189,17 @@ func (u *User) isRequestedChannel(channelName string) bool {
 	_, ok := (*m)[name]
 
 	return ok
+}
+
+func (u *UserBridge) getMsgChanLock(target string) *sync.Mutex {
+	u.msgChanLockMutex.Lock()
+	defer u.msgChanLockMutex.Unlock()
+
+	lock, ok := u.msgChanLocks[target]
+	if !ok {
+		lock = &sync.Mutex{}
+		u.msgChanLocks[target] = lock
+	}
+
+	return lock
 }


### PR DESCRIPTION
This fixes when user sends a post, but realises either it is replying to th wrong thread or the content is wrong. They try to redact it with `s/@@/` but unfortunately, it is still in flight waiting for the MM (or other chat protocol) API to return. The `s/@@/` ends up deleting the wrong message. It can also happen to modifications.