### PR TITLE
docs: fix typo in prefixcontext.md

### DIFF
--- a/prefixcontext.md
+++ b/prefixcontext.md
@@ -12,7 +12,7 @@
 # prefixcontext
 
 When enabling this you'll get a hex number between [000] and [fff] prefixed to each message.
-Every channel/direct message will have a seperate counter.
+Every channel/direct message will have a separate counter.
 
 This way you can see what operation has happened on which message.
 


### PR DESCRIPTION
One-word typo fix in `prefixcontext.md:15`: "will have a seperate counter" -> "separate".

The only other occurrence in the tree is in `vendor/github.com/tomnomnom/linkheader/main.go`, which is vendored third-party code and so left untouched.
