### PR TITLE
Update matterclient to prevent go install failures

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/kenshaw/emoji v0.6.2
 	github.com/matterbridge/logrus-prefixed-formatter v0.5.3-0.20200523233437-d971309a77ba
-	github.com/matterbridge/matterclient v0.0.0-20260822225809-27f5562dae6c
+	github.com/matterbridge/matterclient v0.0.0-20260823200648-05215c297a7b
 	github.com/mattermost/mattermost/server/public v0.1.3
 	github.com/mattn/go-mastodon v0.0.6
 	github.com/mitchellh/mapstructure v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -238,8 +238,8 @@ github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3v
 github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/matterbridge/logrus-prefixed-formatter v0.5.3-0.20200523233437-d971309a77ba h1:XleOY4IjAEIcxAh+IFwT5JT5Ze3RHiYz6m+4ZfZ0rc0=
 github.com/matterbridge/logrus-prefixed-formatter v0.5.3-0.20200523233437-d971309a77ba/go.mod h1:iXGEotOvwI1R1SjLxRc+BF5rUORTMtE0iMZBT2lxqAU=
-github.com/matterbridge/matterclient v0.0.0-20260822225809-27f5562dae6c h1:sfV2XXNADuqjPlbHGGMns2S7d+QERlroLSTG3hOBqPo=
-github.com/matterbridge/matterclient v0.0.0-20260822225809-27f5562dae6c/go.mod h1:5+Z8FKATFPNAzp702walUDWmWo+7FruwxQS1vgE0o6s=
+github.com/matterbridge/matterclient v0.0.0-20260823200648-05215c297a7b h1:vAy6zoJj4i7bym8g8bMCTijkHwMYrd1nFATU9m9t9Ys=
+github.com/matterbridge/matterclient v0.0.0-20260823200648-05215c297a7b/go.mod h1:5+Z8FKATFPNAzp702walUDWmWo+7FruwxQS1vgE0o6s=
 github.com/mattermost/go-i18n v1.11.1-0.20211013152124-5c415071e404 h1:Khvh6waxG1cHc4Cz5ef9n3XVCxRWpAKUtqg9PJl5+y8=
 github.com/mattermost/go-i18n v1.11.1-0.20211013152124-5c415071e404/go.mod h1:RyS7FDNQlzF1PsjbJWHRI35exqaKGSO9qD4iv8QjE34=
 github.com/mattermost/ldap v0.0.0-20231116144001-0f480c025956 h1:Y1Tu/swM31pVwwb2BTCsOdamENjjWCI6qmfHLbk6OZI=

--- a/vendor/github.com/matterbridge/matterclient/matterclient.go
+++ b/vendor/github.com/matterbridge/matterclient/matterclient.go
@@ -1761,6 +1761,7 @@ func (m *Client) PingWS(ctx context.Context) error {
 
 	seq := m.pingSeq.Add(1)
 	ch := make(chan struct{}, 1)
+
 	m.pingChans.Store(seq, ch)
 	defer func() {
 		m.pingChans.Delete(seq)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -112,7 +112,7 @@ github.com/magiconair/properties
 # github.com/matterbridge/logrus-prefixed-formatter v0.5.3-0.20200523233437-d971309a77ba
 ## explicit
 github.com/matterbridge/logrus-prefixed-formatter
-# github.com/matterbridge/matterclient v0.0.0-20260822225809-27f5562dae6c
+# github.com/matterbridge/matterclient v0.0.0-20260823200648-05215c297a7b
 ## explicit; go 1.21
 github.com/matterbridge/matterclient
 # github.com/mattermost/go-i18n v1.11.1-0.20211013152124-5c415071e404


### PR DESCRIPTION
Forgot to do that in https://github.com/42wim/matterircd/pull/836