### PR TITLE
Revert removing the +i invite-only for channel modes - one less character for other things

### DIFF
--- a/mm-go-irckit/server_commands.go
+++ b/mm-go-irckit/server_commands.go
@@ -283,7 +283,7 @@ func CmdMode(s Server, u *User, msg *irc.Message) error {
 
 	mode := "+"
 	if s.Channel(channel).IsPrivate() {
-		mode = "+pi"
+		mode = "+p"
 	}
 
 	r := []*irc.Message{}


### PR DESCRIPTION
We can assume +p / private is laos invite-only