### PR TITLE
Add PING command to allow measuring HTTP REST API (in addition to WebSocket with CTCP)

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -81,7 +81,7 @@ type Bridger interface {
 
 	GetPostSizeLimit() int
 
-	Ping(ctx context.Context) error
+	Ping(ctx context.Context, proto ...string) error
 
 	SendTyping(ctx context.Context, channelName string)
 }

--- a/bridge/mastodon/mastodon.go
+++ b/bridge/mastodon/mastodon.go
@@ -459,7 +459,7 @@ func (m *Mastodon) GetReplayEvents(ctx context.Context, channelID string, since 
 	return []*bridge.Event{}
 }
 
-func (m *Mastodon) Ping(ctx context.Context) error {
+func (m *Mastodon) Ping(ctx context.Context, proto ...string) error {
 	return nil
 }
 

--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -190,12 +190,28 @@ func New(ctx context.Context, cfg *config.Config, cred bridge.Credentials, event
 	return m, mc, nil
 }
 
-func (m *Mattermost) Ping(ctx context.Context) error {
+func (m *Mattermost) Ping(ctx context.Context, proto ...string) error {
 	if m.mc == nil {
 		return errors.New("client not initialized")
 	}
 
-	return m.mc.WsPing(ctx)
+	protocol := "ws"
+	if len(proto) > 0 && proto[0] != "" {
+		protocol = strings.ToLower(proto[0])
+	}
+
+	switch protocol {
+	case "http", "rest":
+		_, err := m.mc.HttpPing(ctx)
+		if err != nil {
+			return err
+		}
+
+		return nil
+
+	default:
+		return m.mc.WsPing(ctx)
+	}
 }
 
 func (m *Mattermost) SendTyping(ctx context.Context, channelName string) {

--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -1091,7 +1091,7 @@ func (s *Slack) GetReplayEvents(ctx context.Context, channelID string, since int
 	return []*bridge.Event{}
 }
 
-func (s *Slack) Ping(ctx context.Context) error {
+func (s *Slack) Ping(ctx context.Context, proto ...string) error {
 	return nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/kenshaw/emoji v0.6.2
 	github.com/matterbridge/logrus-prefixed-formatter v0.5.3-0.20200523233437-d971309a77ba
-	github.com/matterbridge/matterclient v0.0.0-20260830032507-e084a83112ad
+	github.com/matterbridge/matterclient v0.0.0-20260830213501-25c8ad705a49
 	github.com/mattermost/mattermost/server/public v0.1.3
 	github.com/mattn/go-mastodon v0.0.6
 	github.com/mitchellh/mapstructure v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -238,8 +238,8 @@ github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3v
 github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/matterbridge/logrus-prefixed-formatter v0.5.3-0.20200523233437-d971309a77ba h1:XleOY4IjAEIcxAh+IFwT5JT5Ze3RHiYz6m+4ZfZ0rc0=
 github.com/matterbridge/logrus-prefixed-formatter v0.5.3-0.20200523233437-d971309a77ba/go.mod h1:iXGEotOvwI1R1SjLxRc+BF5rUORTMtE0iMZBT2lxqAU=
-github.com/matterbridge/matterclient v0.0.0-20260830032507-e084a83112ad h1:60t6jNUOThXJevf6iga/rvKi9t6iAn38WQagyvV9DRE=
-github.com/matterbridge/matterclient v0.0.0-20260830032507-e084a83112ad/go.mod h1:5+Z8FKATFPNAzp702walUDWmWo+7FruwxQS1vgE0o6s=
+github.com/matterbridge/matterclient v0.0.0-20260830213501-25c8ad705a49 h1:5+uR8AnMCHhoqZt1b6b7/nRAZkzRWhgKEe0T9pPmzk0=
+github.com/matterbridge/matterclient v0.0.0-20260830213501-25c8ad705a49/go.mod h1:5+Z8FKATFPNAzp702walUDWmWo+7FruwxQS1vgE0o6s=
 github.com/mattermost/go-i18n v1.11.1-0.20211013152124-5c415071e404 h1:Khvh6waxG1cHc4Cz5ef9n3XVCxRWpAKUtqg9PJl5+y8=
 github.com/mattermost/go-i18n v1.11.1-0.20211013152124-5c415071e404/go.mod h1:RyS7FDNQlzF1PsjbJWHRI35exqaKGSO9qD4iv8QjE34=
 github.com/mattermost/ldap v0.0.0-20231116144001-0f480c025956 h1:Y1Tu/swM31pVwwb2BTCsOdamENjjWCI6qmfHLbk6OZI=

--- a/mm-go-irckit/service.go
+++ b/mm-go-irckit/service.go
@@ -1,6 +1,7 @@
 package irckit
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"regexp"
@@ -454,6 +455,24 @@ func part(u *User, toUser *User, args []string, service string) {
 	}
 }
 
+func ping(u *User, toUser *User, args []string, service string) {
+	pingCtx, cancel := context.WithTimeout(u.ctx, 5*time.Second)
+	defer cancel()
+
+	start := time.Now()
+
+	err := u.br.Ping(pingCtx, "http")
+	if err != nil {
+		u.MsgUser(toUser, fmt.Sprintf("HTTP REST PING failed: %v", err))
+
+		return
+	}
+
+	duration := time.Since(start).Round(time.Millisecond)
+
+	u.MsgUser(toUser, fmt.Sprintf("PONG (HTTP REST): status=OK, latency=%s", duration))
+}
+
 //nolint:funlen,gocognit,gocyclo,cyclop
 func scrollback(u *User, toUser *User, args []string, service string) {
 	if service != "mattermost" {
@@ -689,6 +708,7 @@ var cmds = map[string]Command{
 	"login":            {handler: login, minParams: 2, maxParams: 5},
 	"logout":           {handler: logout, login: true, minParams: 0, maxParams: 0},
 	"part":             {handler: part, login: true, minParams: 1, maxParams: 1},
+	"ping":             {handler: ping, login: true, minParams: 0, maxParams: 0},
 	"replay":           {handler: replay, login: true, minParams: 1, maxParams: 2},
 	"scrollback":       {handler: scrollback, login: true, minParams: 2, maxParams: 2},
 	"search":           {handler: search, login: true, minParams: 1, maxParams: -1},

--- a/vendor/github.com/matterbridge/matterclient/matterclient.go
+++ b/vendor/github.com/matterbridge/matterclient/matterclient.go
@@ -1322,6 +1322,23 @@ func (m *Client) HandleRetry(ctx context.Context, name string, err error, curren
 	}
 }
 
+// HttpPing sends an HTTP API GET /api/v4/system/ping request and returns the server status.
+func (m *Client) HttpPing(ctx context.Context) (string, error) {
+	if m.Client == nil {
+		return "", errors.New("client not initialized")
+	}
+
+	m.logger.Trace("HttpPing: sending ping")
+	m.apiLogger.Warn("HttpPing: GetPing")
+
+	status, _, err := m.Client.GetPing(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	return status, nil
+}
+
 // IsAborted checks if the user disconnected, logout was called, or the context died.
 func (m *Client) IsAborted(ctx context.Context) bool {
 	if m.WsQuit {

--- a/vendor/github.com/matterbridge/matterclient/matterclient.go
+++ b/vendor/github.com/matterbridge/matterclient/matterclient.go
@@ -1329,12 +1329,15 @@ func (m *Client) HttpPing(ctx context.Context) (string, error) {
 	}
 
 	m.logger.Trace("HttpPing: sending ping")
-	m.apiLogger.Warn("HttpPing: GetPing")
 
 	status, _, err := m.Client.GetPing(ctx)
 	if err != nil {
+		m.apiLogger.Warnf("HttpPing: GetPing: %#v", err)
+
 		return "", err
 	}
+
+	m.apiLogger.Infof("HttpPing: GetPing: %s", status)
 
 	return status, nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -112,7 +112,7 @@ github.com/magiconair/properties
 # github.com/matterbridge/logrus-prefixed-formatter v0.5.3-0.20200523233437-d971309a77ba
 ## explicit
 github.com/matterbridge/logrus-prefixed-formatter
-# github.com/matterbridge/matterclient v0.0.0-20260830032507-e084a83112ad
+# github.com/matterbridge/matterclient v0.0.0-20260830213501-25c8ad705a49
 ## explicit; go 1.21
 github.com/matterbridge/matterclient
 # github.com/mattermost/go-i18n v1.11.1-0.20211013152124-5c415071e404


### PR DESCRIPTION
CTCP PING was added recently in https://github.com/42wim/matterircd/pull/836 but that's measuring latency via the `WebSocket`. Sometimes, we want to measure HTTP REST API as well. This adds support for that.