### PR TITLE
golangci-lint push to only run on master

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -1,5 +1,9 @@
 name: Development
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
 jobs:
   lint:
     name: golangci-lint


### PR DESCRIPTION
Fixes failures in https://github.com/42wim/matterircd/pull/867