### PR TITLE
Add support for customising how to preserve new/empty lines

### DIFF
--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -2208,6 +2208,7 @@ func (m *Mattermost) parseMessageAttachments(b *strings.Builder, attachments []*
 	disableEmoji := rc.Mattermost.Formatter.DisableEmoji
 	customEmoji := rc.Mattermost.Formatter.CustomEmoji
 	enableIRCHexColors := rc.Mattermost.Formatter.EnableIRCHexColors
+	preserveNewLines := rc.Mattermost.Formatter.PreserveNewLines
 	messageAttachmentShortFieldMaxLineLength := rc.Mattermost.MessageAttachmentShortFieldMaxLineLength
 	messageAttachmentOmitFieldTitles := rc.Mattermost.MessageAttachmentOmitFieldTitles
 
@@ -2364,6 +2365,7 @@ func (m *Mattermost) parseMessageAttachments(b *strings.Builder, attachments []*
 			CodeBlockSeparator: codeBlockSeparator,
 			BlockquoteChar:     blockquoteChar,
 			InlineCodeChar:     inlineCode,
+			PreserveNewLines:   preserveNewLines,
 		}
 
 		if attachment.Text != "" && !isTextDup {
@@ -2686,6 +2688,7 @@ func (m *Mattermost) parsePreviewPost(b *strings.Builder, user string, channel s
 	syntaxHighlighting := rc.Mattermost.Formatter.SyntaxHighlighting
 	codeBlockPrefix := rc.Mattermost.Formatter.CodeBlockPrefix
 	codeBlockSeparator := rc.Mattermost.Formatter.CodeBlockSeparator
+	preserveNewLines := rc.Mattermost.Formatter.PreserveNewLines
 	disableMarkdown := rc.Mattermost.Formatter.DisableMarkdown
 	disableEmoji := rc.Mattermost.Formatter.DisableEmoji
 	customEmoji := rc.Mattermost.Formatter.CustomEmoji
@@ -2770,6 +2773,7 @@ func (m *Mattermost) parsePreviewPost(b *strings.Builder, user string, channel s
 			CodeBlockSeparator: codeBlockSeparator,
 			BlockquoteChar:     blockquoteChar,
 			InlineCodeChar:     inlineCode,
+			PreserveNewLines:   preserveNewLines,
 		}
 
 		trimmedBlockquoteChar := strings.TrimSpace(blockquoteChar)

--- a/config/config.go
+++ b/config/config.go
@@ -116,6 +116,8 @@ type FormatterConfig struct {
 	Unicode bool
 
 	EnableIRCHexColors bool
+
+	PreserveNewLines string
 }
 
 type MattermostConfig struct {
@@ -273,6 +275,8 @@ func (c *Config) buildRuntimeCfg() *RuntimeConfig {
 		Unicode: c.v.GetBool("mattermost.Unicode"),
 
 		EnableIRCHexColors: c.v.GetBool("mattermost.EnableIRCHexColors"),
+
+		PreserveNewLines: c.v.GetString("mattermost.PreserveNewLines"),
 	}
 	slFormatter := FormatterConfig{
 		DisableEmoji: c.v.GetBool("slack.DisableEmoji"),
@@ -291,6 +295,8 @@ func (c *Config) buildRuntimeCfg() *RuntimeConfig {
 		Unicode: c.v.GetBool("slack.Unicode"),
 
 		EnableIRCHexColors: c.v.GetBool("slack.EnableIRCHexColors"),
+
+		PreserveNewLines: c.v.GetString("slack.PreserveNewLines"),
 	}
 	mdFormatter := FormatterConfig{
 		DisableEmoji: c.v.GetBool("mastodon.DisableEmoji"),
@@ -309,6 +315,8 @@ func (c *Config) buildRuntimeCfg() *RuntimeConfig {
 		Unicode: c.v.GetBool("mastodon.Unicode"),
 
 		EnableIRCHexColors: c.v.GetBool("mastodon.EnableIRCHexColors"),
+
+		PreserveNewLines: c.v.GetString("mastodon.PreserveNewLines"),
 	}
 
 	return &RuntimeConfig{

--- a/matterircd.toml.example
+++ b/matterircd.toml.example
@@ -172,6 +172,9 @@ HideReactions = false
 #MarkdownBlockQuoteChar = "|"
 MarkdownInlineCode = ""
 
+# Change behaviour on how to preserve new/empty lines ("all", "max-one", or "none")
+#PreserveNewLines = "all"
+
 #Only join direct/group messages when someone talks. This stops from cluttering your 
 #irc client with lots of windows.
 #If set to true dm/group messages will be joined on startup and not only on talk in the channel.

--- a/mm-go-irckit/service.go
+++ b/mm-go-irckit/service.go
@@ -321,6 +321,7 @@ func details(u *User, toUser *User, args []string, service string) {
 	blockQuoteChar, codeBlockPrefix := u.getMarkdownBlockCodePrefix()
 	syntaxHighlighting := u.br.FormatterConfig().SyntaxHighlighting
 	codeBlockSeparator := u.br.FormatterConfig().CodeBlockSeparator
+	preserveNewLines := u.br.FormatterConfig().PreserveNewLines
 
 	opts := utils.ProcessMessageOpts{
 		DisableEmoji:       disableEmoji,
@@ -331,6 +332,7 @@ func details(u *User, toUser *User, args []string, service string) {
 		CodeBlockSeparator: codeBlockSeparator,
 		BlockquoteChar:     blockQuoteChar,
 		InlineCodeChar:     inlineCode,
+		PreserveNewLines:   preserveNewLines,
 	}
 
 	for _, event := range events {
@@ -579,6 +581,7 @@ func dispatchHistoricalEvent(u *User, toUser *User, event *bridge.Event, searchC
 	blockQuoteChar, codeBlockPrefix := u.getMarkdownBlockCodePrefix()
 	syntaxHighlighting := u.br.FormatterConfig().SyntaxHighlighting
 	codeBlockSeparator := u.br.FormatterConfig().CodeBlockSeparator
+	preserveNewLines := u.br.FormatterConfig().PreserveNewLines
 
 	opts := utils.ProcessMessageOpts{
 		DisableEmoji:       disableEmoji,
@@ -589,6 +592,7 @@ func dispatchHistoricalEvent(u *User, toUser *User, event *bridge.Event, searchC
 		CodeBlockSeparator: codeBlockSeparator,
 		BlockquoteChar:     blockQuoteChar,
 		InlineCodeChar:     inlineCode,
+		PreserveNewLines:   preserveNewLines,
 	}
 
 	textToProcess := utils.WrapMessage(text, 460)
@@ -1290,6 +1294,7 @@ func summarize(u *User, toUser *User, args []string, service string) {
 	blockQuoteChar, codeBlockPrefix := u.getMarkdownBlockCodePrefix()
 	syntaxHighlighting := u.br.FormatterConfig().SyntaxHighlighting
 	codeBlockSeparator := u.br.FormatterConfig().CodeBlockSeparator
+	preserveNewLines := u.br.FormatterConfig().PreserveNewLines
 
 	opts := utils.ProcessMessageOpts{
 		DisableMarkdown:    disableMarkdown,
@@ -1299,6 +1304,7 @@ func summarize(u *User, toUser *User, args []string, service string) {
 		CodeBlockSeparator: codeBlockSeparator,
 		BlockquoteChar:     blockQuoteChar,
 		InlineCodeChar:     inlineCode,
+		PreserveNewLines:   preserveNewLines,
 	}
 
 	utils.ProcessMessageText(summary, opts, func(line string) {

--- a/mm-go-irckit/userbridge.go
+++ b/mm-go-irckit/userbridge.go
@@ -284,6 +284,7 @@ func (u *User) handleDirectMessageEvent(event *bridge.DirectMessageEvent) {
 	showContextMulti := u.br.BridgeConfig().ShowContextMulti
 	syntaxHighlighting := u.br.FormatterConfig().SyntaxHighlighting
 	codeBlockSeparator := u.br.FormatterConfig().CodeBlockSeparator
+	preserveNewLines := u.br.FormatterConfig().PreserveNewLines
 
 	text = utils.WrapMessage(text, maxlen)
 	addPrefix := false
@@ -315,6 +316,7 @@ func (u *User) handleDirectMessageEvent(event *bridge.DirectMessageEvent) {
 		CodeBlockSeparator: codeBlockSeparator,
 		BlockquoteChar:     blockQuoteChar,
 		InlineCodeChar:     inlineCode,
+		PreserveNewLines:   preserveNewLines,
 	}
 
 	emitLine := func(line string) {
@@ -525,6 +527,7 @@ func (u *User) handleChannelMessageEvent(event *bridge.ChannelMessageEvent) {
 	showContextMulti := u.br.BridgeConfig().ShowContextMulti
 	syntaxHighlighting := u.br.FormatterConfig().SyntaxHighlighting
 	codeBlockSeparator := u.br.FormatterConfig().CodeBlockSeparator
+	preserveNewLines := u.br.FormatterConfig().PreserveNewLines
 
 	text = utils.WrapMessage(text, maxlen)
 	addPrefix := false
@@ -556,6 +559,7 @@ func (u *User) handleChannelMessageEvent(event *bridge.ChannelMessageEvent) {
 		CodeBlockSeparator: codeBlockSeparator,
 		BlockquoteChar:     blockQuoteChar,
 		InlineCodeChar:     inlineCode,
+		PreserveNewLines:   preserveNewLines,
 	}
 
 	emitLine := func(line string) {
@@ -1495,6 +1499,7 @@ func (u *User) replayHistory(brchannel *bridge.ChannelInfo, since int64, logSinc
 	blockQuoteChar, codeBlockPrefix := u.getMarkdownBlockCodePrefix()
 	syntaxHighlighting := u.br.FormatterConfig().SyntaxHighlighting
 	codeBlockSeparator := u.br.FormatterConfig().CodeBlockSeparator
+	preserveNewLines := u.br.FormatterConfig().PreserveNewLines
 
 	opts := utils.ProcessMessageOpts{
 		DisableEmoji:       disableEmoji,
@@ -1505,6 +1510,7 @@ func (u *User) replayHistory(brchannel *bridge.ChannelInfo, since int64, logSinc
 		CodeBlockSeparator: codeBlockSeparator,
 		BlockquoteChar:     blockQuoteChar,
 		InlineCodeChar:     inlineCode,
+		PreserveNewLines:   preserveNewLines,
 	}
 
 	for _, event := range events {

--- a/utils/formatters.go
+++ b/utils/formatters.go
@@ -430,7 +430,7 @@ func ProcessMessageText(text string, opts ProcessMessageOpts, yield func(line st
 	if inCodeBlock {
 		FormatFullCodeBlock(codeBuilder.String(), lexer, currentIndent, opts, yield)
 	} else if opts.PreserveNewLines == "all" || opts.PreserveNewLines == "" {
-		for j := 0; j < emptyLines; j++ {
+		for range emptyLines {
 			yield("")
 		}
 	}
@@ -876,9 +876,9 @@ func flushEmptyLines(count int, mode string, hasContent bool, yield func(line st
 		}
 
 	case "all":
-		fallthrough
+		fallthrough //nolint:gocritic
 	default:
-		for j := 0; j < count; j++ {
+		for range count {
 			yield("")
 		}
 	}

--- a/utils/formatters.go
+++ b/utils/formatters.go
@@ -28,6 +28,8 @@ type ProcessMessageOpts struct {
 	CodeBlockSeparator string
 	BlockquoteChar     string
 	InlineCodeChar     string
+
+	PreserveNewLines string // "all" (default), "max-one", or "none" / "zero"
 }
 
 // SummaryOpts holds configuration for shortening and summarizing text.
@@ -323,7 +325,8 @@ func ProcessMessageText(text string, opts ProcessMessageOpts, yield func(line st
 
 	var (
 		codeBuilder      strings.Builder
-		emptyLines       = make([]string, 0, 4)
+		emptyLines       int
+		hasContent       bool
 		lastBlockWasCode bool
 		inCodeBlock      bool
 		codeBlockMarker  string
@@ -343,6 +346,7 @@ func ProcessMessageText(text string, opts ProcessMessageOpts, yield func(line st
 			if strings.HasPrefix(trimmed, codeBlockMarker) {
 				inCodeBlock = false
 				lastBlockWasCode = true
+				hasContent = true
 
 				FormatFullCodeBlock(codeBuilder.String(), lexer, currentIndent, opts, yield)
 				codeBuilder.Reset() // Frees builder state for next block
@@ -388,13 +392,11 @@ func ProcessMessageText(text string, opts ProcessMessageOpts, yield func(line st
 				yield(currentIndent + opts.CodeBlockSeparator)
 			} else if !lastBlockWasCode {
 				// Flush empty lines if they weren't between code blocks
-				for _, el := range emptyLines {
-					yield(el)
-				}
+				flushEmptyLines(emptyLines, opts.PreserveNewLines, hasContent, yield)
 			}
 
 			// Reset slice length without freeing memory
-			emptyLines = emptyLines[:0]
+			emptyLines = 0
 
 			codeBuilder.Grow(256)
 
@@ -403,14 +405,12 @@ func ProcessMessageText(text string, opts ProcessMessageOpts, yield func(line st
 
 		if trimmed == "" {
 			// Buffer empty lines
-			emptyLines = append(emptyLines, line)
+			emptyLines++
 		} else {
 			// Normal text line - flush buffered empty lines first
-			for _, el := range emptyLines {
-				yield(el)
-			}
-
-			emptyLines = emptyLines[:0]
+			flushEmptyLines(emptyLines, opts.PreserveNewLines, hasContent, yield)
+			emptyLines = 0
+			hasContent = true
 			lastBlockWasCode = false
 
 			line = FormatMarkdownAndEmoji(
@@ -429,9 +429,9 @@ func ProcessMessageText(text string, opts ProcessMessageOpts, yield func(line st
 	// Flush remaining state if EOF reached
 	if inCodeBlock {
 		FormatFullCodeBlock(codeBuilder.String(), lexer, currentIndent, opts, yield)
-	} else {
-		for _, el := range emptyLines {
-			yield(el)
+	} else if opts.PreserveNewLines == "all" || opts.PreserveNewLines == "" {
+		for j := 0; j < emptyLines; j++ {
+			yield("")
 		}
 	}
 }
@@ -859,4 +859,27 @@ func WrapMessage(msg string, maxLen int) string {
 	// Flush whatever remains of the string
 	b.WriteString(msg[lastWrite:])
 	return b.String()
+}
+
+func flushEmptyLines(count int, mode string, hasContent bool, yield func(line string)) {
+	if count == 0 {
+		return
+	}
+
+	switch mode {
+	case "none", "zero":
+		return
+
+	case "max-one":
+		if hasContent {
+			yield("")
+		}
+
+	case "all":
+		fallthrough
+	default:
+		for j := 0; j < count; j++ {
+			yield("")
+		}
+	}
 }


### PR DESCRIPTION
So for some text such as:

```
Testing new line stuff

Testing with one line above


Testing with two lines above
Testing with one below

```

With the default of `always` or undefined, we get:

```
|09:21 <hloeung> [b6mzb…] Testing new line stuff
|09:21 <hloeung>
|09:21 <hloeung> Testing with one line above
|09:21 <hloeung>
|09:21 <hloeung>
|09:21 <hloeung> Testing with two lines above
|09:21 <hloeung> Testing with one below
```

With `mattermost.PreserveNewLines` set to `none`, we get:

```
|09:21 <hloeung> [b6mzb…] Testing new line stuff
|09:21 <hloeung> Testing with one line above
|09:21 <hloeung> Testing with two lines above
|09:21 <hloeung> Testing with one below
```

With `mattermost.PreserveNewLines` set to `max-one`, we get:

```
|09:21 <hloeung> [b6mzb…] Testing new line stuff
|09:21 <hloeung>
|09:21 <hloeung> Testing with one line above
|09:21 <hloeung>
|09:21 <hloeung> Testing with two lines above
|09:21 <hloeung> Testing with one below
```